### PR TITLE
feat: 메모리 계층화 도입 (scratchpad→working→long-term) (#42)

### DIFF
--- a/src/cron/jobs.ts
+++ b/src/cron/jobs.ts
@@ -118,6 +118,12 @@ export function createBuiltinJobs(deps: CronJobDeps): CronJob[] {
 			handler: () => runMemoryDecay(deps),
 		},
 		{
+			id: "memory-tier-maintenance",
+			intervalMs: ONE_HOUR,
+			runOnStart: false,
+			handler: () => runMemoryTierMaintenance(deps),
+		},
+		{
 			id: "history-prune",
 			intervalMs: TWENTY_FOUR_HOURS,
 			runOnStart: false,
@@ -476,6 +482,47 @@ async function runMemoryDecay(deps: CronJobDeps): Promise<string | void> {
 	logger.info("Memory decay completed", { archived });
 	if (archived > 0) {
 		return `기억 감쇠 처리 완료! 약해진 기억 ${archived}개를 보관함으로 옮겼어요.`;
+	}
+}
+
+/**
+ * Memory tier maintenance — expire stale scratchpad entries and promote
+ * eligible entries to higher tiers. Runs every hour (Issue #42).
+ *
+ * Promotion rules:
+ *   scratchpad → working: referenceCount >= 2 OR confidence >= 0.85
+ *   working → long-term:  referenceCount >= 5 AND confidence >= 0.8
+ *
+ * Logs tier statistics after each run for observability.
+ */
+async function runMemoryTierMaintenance(
+	deps: CronJobDeps,
+): Promise<string | void> {
+	const { expired, scratchpadToWorking, workingToLongTerm } =
+		await deps.knowledge.runTierMaintenance();
+
+	const stats = await deps.knowledge.getTierStats();
+	logger.info("Memory tier maintenance completed", {
+		expired,
+		scratchpadToWorking,
+		workingToLongTerm,
+		stats,
+	});
+
+	const parts: string[] = [];
+	if (expired > 0) parts.push(`만료 ${expired}개`);
+	if (scratchpadToWorking > 0) parts.push(`scratchpad→working ${scratchpadToWorking}개`);
+	if (workingToLongTerm > 0) parts.push(`working→long-term ${workingToLongTerm}개`);
+
+	logger.info("Memory tier stats", {
+		scratchpad: stats.scratchpad,
+		working: stats.working,
+		longTerm: stats.longTerm,
+		total: stats.total,
+	});
+
+	if (parts.length > 0) {
+		return `메모리 계층 정리 완료! ${parts.join(", ")} (전체: scratchpad ${stats.scratchpad}, working ${stats.working}, long-term ${stats.longTerm})`;
 	}
 }
 

--- a/src/knowledge-feed/subscriber.ts
+++ b/src/knowledge-feed/subscriber.ts
@@ -97,6 +97,9 @@ export class FeedSubscriber {
 				strength: 1.0,
 				lastReferencedAt: now,
 				referenceCount: 0,
+				tier: "scratchpad",
+				tierCreatedAt: now,
+				promotionScore: 0,
 			};
 
 			await this.knowledge.upsert(localEntry);

--- a/src/memory/knowledge.test.ts
+++ b/src/memory/knowledge.test.ts
@@ -2,7 +2,7 @@
  * Tests for KnowledgeManager — forgetting curve integration.
  * Covers: reinforce, applyDecayAll, archiveWeak, listFading,
  * backward compatibility with entries missing new fields,
- * and strength-weighted search.
+ * strength-weighted search, and memory tier management (Issue #42).
  */
 
 import { randomUUID } from "node:crypto";
@@ -32,6 +32,10 @@ function makeEntry(overrides: Partial<KnowledgeEntry> = {}): KnowledgeEntry {
 		strength: 1.0,
 		lastReferencedAt: now,
 		referenceCount: 0,
+		// Tier fields (Issue #42)
+		tier: "scratchpad",
+		tierCreatedAt: now,
+		promotionScore: 0,
 		...overrides,
 	};
 }
@@ -389,6 +393,455 @@ describe("KnowledgeManager", () => {
 			expect(result).not.toBeNull();
 			// Should contain some kind of strength indicator
 			expect(result?.text).toContain("Node.js async");
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// Memory Tier (Issue #42)
+	// -----------------------------------------------------------------------
+
+	describe("memory tier", () => {
+		// -------------------------------------------------------------------
+		// Default tier assignment
+		// -------------------------------------------------------------------
+
+		describe("default tier assignment", () => {
+			it("assigns 'scratchpad' tier by default when not specified", async () => {
+				const entry = makeEntry();
+				await manager.upsert(entry);
+
+				const stored = await manager.get(entry.id);
+				expect(stored?.tier).toBe("scratchpad");
+			});
+
+			it("preserves explicitly assigned tier", async () => {
+				const entry = makeEntry({ tier: "working" });
+				await manager.upsert(entry);
+
+				const stored = await manager.get(entry.id);
+				expect(stored?.tier).toBe("working");
+			});
+
+			it("sets tierCreatedAt on upsert", async () => {
+				const before = Date.now();
+				const entry = makeEntry();
+				await manager.upsert(entry);
+				const after = Date.now();
+
+				const stored = await manager.get(entry.id);
+				expect(stored?.tierCreatedAt).toBeGreaterThanOrEqual(before);
+				expect(stored?.tierCreatedAt).toBeLessThanOrEqual(after);
+			});
+
+			it("computes promotionScore on upsert", async () => {
+				const entry = makeEntry({
+					referenceCount: 3,
+					confidence: 0.8,
+					strength: 0.8,
+				});
+				await manager.upsert(entry);
+
+				const stored = await manager.get(entry.id);
+				// promotionScore = 3*0.4 + 0.8*0.4 + 0.2 = 1.2 + 0.32 + 0.2 = 1.72
+				expect(stored?.promotionScore).toBeGreaterThan(0);
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// Backward compatibility with entries missing tier fields
+		// -------------------------------------------------------------------
+
+		describe("backward compatibility for tier fields", () => {
+			it("reads old entries without tier fields and defaults to 'scratchpad'", async () => {
+				const id = randomUUID();
+				const oldEntry = {
+					id,
+					topic: "old topic without tier",
+					content: "content",
+					source: "taught",
+					createdAt: Date.now(),
+					updatedAt: Date.now(),
+					confidence: 0.8,
+					tags: [],
+					strength: 1.0,
+					lastReferencedAt: Date.now(),
+					referenceCount: 0,
+				};
+				const safeName = id.replace(/[^a-zA-Z0-9_-]/g, "_");
+				await writeFile(
+					join(memoryDir, `${safeName}.json`),
+					JSON.stringify(oldEntry, null, 2),
+					"utf8",
+				);
+
+				const read = await manager.get(id);
+				expect(read).not.toBeNull();
+				expect(read?.tier).toBe("scratchpad");
+				expect(read?.tierCreatedAt).toBeDefined();
+				expect(read?.promotionScore).toBeGreaterThanOrEqual(0);
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// promotionScore calculation
+		// -------------------------------------------------------------------
+
+		describe("computePromotionScore", () => {
+			it("returns higher score for high referenceCount + confidence + strength", async () => {
+				const highScore = makeEntry({
+					referenceCount: 10,
+					confidence: 0.9,
+					strength: 0.9,
+				});
+				const lowScore = makeEntry({
+					referenceCount: 0,
+					confidence: 0.5,
+					strength: 0.3,
+				});
+
+				await manager.upsert(highScore);
+				await manager.upsert(lowScore);
+
+				const h = await manager.get(highScore.id);
+				const l = await manager.get(lowScore.id);
+				expect(h!.promotionScore).toBeGreaterThan(l!.promotionScore);
+			});
+
+			it("adds 0.2 bonus when strength > 0.7", async () => {
+				const withBonus = makeEntry({ referenceCount: 0, confidence: 0.5, strength: 0.8 });
+				const withoutBonus = makeEntry({ referenceCount: 0, confidence: 0.5, strength: 0.5 });
+
+				await manager.upsert(withBonus);
+				await manager.upsert(withoutBonus);
+
+				const wb = await manager.get(withBonus.id);
+				const wob = await manager.get(withoutBonus.id);
+				// Difference should be ~0.2
+				expect(wb!.promotionScore - wob!.promotionScore).toBeCloseTo(0.2, 5);
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// scratchpad TTL expiry
+		// -------------------------------------------------------------------
+
+		describe("scratchpad TTL expiry (expireScratchpad)", () => {
+			it("deletes scratchpad entries whose TTL has expired", async () => {
+				const expired = makeEntry({
+					tier: "scratchpad",
+					tierCreatedAt: Date.now() - 2 * 3_600_000, // 2 hours ago
+					scratchpadTtlMs: 3_600_000, // 1 hour TTL
+				});
+				await manager.upsert(expired);
+
+				const removed = await manager.expireScratchpad();
+
+				expect(removed).toBe(1);
+				expect(await manager.get(expired.id)).toBeNull();
+			});
+
+			it("keeps scratchpad entries whose TTL has not expired", async () => {
+				const fresh = makeEntry({
+					tier: "scratchpad",
+					tierCreatedAt: Date.now() - 1_000, // 1 second ago
+					scratchpadTtlMs: 3_600_000, // 1 hour TTL
+				});
+				await manager.upsert(fresh);
+
+				const removed = await manager.expireScratchpad();
+
+				expect(removed).toBe(0);
+				expect(await manager.get(fresh.id)).not.toBeNull();
+			});
+
+			it("does not delete working or long-term entries", async () => {
+				const working = makeEntry({
+					tier: "working",
+					tierCreatedAt: Date.now() - 999_999_999,
+				});
+				const longTerm = makeEntry({
+					tier: "long-term",
+					tierCreatedAt: Date.now() - 999_999_999,
+				});
+				await manager.upsert(working);
+				await manager.upsert(longTerm);
+
+				const removed = await manager.expireScratchpad();
+
+				expect(removed).toBe(0);
+				expect(await manager.get(working.id)).not.toBeNull();
+				expect(await manager.get(longTerm.id)).not.toBeNull();
+			});
+
+			it("promotes eligible scratchpad entries before expiring them", async () => {
+				// Entry eligible for promotion (referenceCount >= 2)
+				const promotable = makeEntry({
+					tier: "scratchpad",
+					tierCreatedAt: Date.now() - 2 * 3_600_000,
+					scratchpadTtlMs: 3_600_000,
+					referenceCount: 3, // >= 2, eligible for working
+					confidence: 0.7,
+				});
+				await manager.upsert(promotable);
+
+				const removed = await manager.expireScratchpad();
+
+				// Should NOT be deleted — was promoted instead
+				expect(removed).toBe(0);
+				const stored = await manager.get(promotable.id);
+				expect(stored?.tier).toBe("working");
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// Tier promotion
+		// -------------------------------------------------------------------
+
+		describe("promoteTiers", () => {
+			it("promotes scratchpad → working when referenceCount >= 2", async () => {
+				const entry = makeEntry({
+					tier: "scratchpad",
+					referenceCount: 2,
+					confidence: 0.6,
+				});
+				await manager.upsert(entry);
+
+				const result = await manager.promoteTiers();
+
+				expect(result.scratchpadToWorking).toBe(1);
+				const stored = await manager.get(entry.id);
+				expect(stored?.tier).toBe("working");
+			});
+
+			it("promotes scratchpad → working when confidence >= 0.85", async () => {
+				const entry = makeEntry({
+					tier: "scratchpad",
+					referenceCount: 0,
+					confidence: 0.9,
+				});
+				await manager.upsert(entry);
+
+				const result = await manager.promoteTiers();
+
+				expect(result.scratchpadToWorking).toBe(1);
+				const stored = await manager.get(entry.id);
+				expect(stored?.tier).toBe("working");
+			});
+
+			it("does NOT promote scratchpad when conditions not met", async () => {
+				const entry = makeEntry({
+					tier: "scratchpad",
+					referenceCount: 1,
+					confidence: 0.7,
+				});
+				await manager.upsert(entry);
+
+				const result = await manager.promoteTiers();
+
+				expect(result.scratchpadToWorking).toBe(0);
+				const stored = await manager.get(entry.id);
+				expect(stored?.tier).toBe("scratchpad");
+			});
+
+			it("promotes working → long-term when referenceCount >= 5 AND confidence >= 0.8", async () => {
+				const entry = makeEntry({
+					tier: "working",
+					referenceCount: 5,
+					confidence: 0.8,
+				});
+				await manager.upsert(entry);
+
+				const result = await manager.promoteTiers();
+
+				expect(result.workingToLongTerm).toBe(1);
+				const stored = await manager.get(entry.id);
+				expect(stored?.tier).toBe("long-term");
+			});
+
+			it("does NOT promote working → long-term when referenceCount < 5", async () => {
+				const entry = makeEntry({
+					tier: "working",
+					referenceCount: 4,
+					confidence: 0.9,
+				});
+				await manager.upsert(entry);
+
+				const result = await manager.promoteTiers();
+
+				expect(result.workingToLongTerm).toBe(0);
+				expect((await manager.get(entry.id))?.tier).toBe("working");
+			});
+
+			it("does NOT promote working → long-term when confidence < 0.8", async () => {
+				const entry = makeEntry({
+					tier: "working",
+					referenceCount: 10,
+					confidence: 0.79,
+				});
+				await manager.upsert(entry);
+
+				const result = await manager.promoteTiers();
+
+				expect(result.workingToLongTerm).toBe(0);
+				expect((await manager.get(entry.id))?.tier).toBe("working");
+			});
+
+			it("updates tierCreatedAt when promoting", async () => {
+				const oldTierCreatedAt = Date.now() - 5_000;
+				const entry = makeEntry({
+					tier: "scratchpad",
+					tierCreatedAt: oldTierCreatedAt,
+					referenceCount: 2,
+					confidence: 0.7,
+				});
+				await manager.upsert(entry);
+
+				const before = Date.now();
+				await manager.promoteTiers();
+				const after = Date.now();
+
+				const stored = await manager.get(entry.id);
+				expect(stored?.tierCreatedAt).toBeGreaterThanOrEqual(before);
+				expect(stored?.tierCreatedAt).toBeLessThanOrEqual(after);
+			});
+
+			it("returns correct counts for multiple promotions", async () => {
+				const sp1 = makeEntry({ tier: "scratchpad", referenceCount: 3, confidence: 0.7 });
+				const sp2 = makeEntry({ tier: "scratchpad", referenceCount: 0, confidence: 0.9 });
+				const sp3 = makeEntry({ tier: "scratchpad", referenceCount: 0, confidence: 0.5 }); // no promotion
+				const wk1 = makeEntry({ tier: "working", referenceCount: 6, confidence: 0.85 });
+				const wk2 = makeEntry({ tier: "working", referenceCount: 2, confidence: 0.9 }); // no promotion
+
+				for (const e of [sp1, sp2, sp3, wk1, wk2]) {
+					await manager.upsert(e);
+				}
+
+				const result = await manager.promoteTiers();
+
+				expect(result.scratchpadToWorking).toBe(2);
+				expect(result.workingToLongTerm).toBe(1);
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// Retrieval tier priority (search with tier weighting)
+		// -------------------------------------------------------------------
+
+		describe("search with tier priority weighting", () => {
+			it("ranks long-term > working > scratchpad for equal relevance", async () => {
+				const longTerm = makeEntry({
+					topic: "golang concurrency",
+					content: "goroutines and channels",
+					tier: "long-term",
+					strength: 0.8,
+					confidence: 0.8,
+				});
+				const working = makeEntry({
+					topic: "golang concurrency",
+					content: "goroutines and channels",
+					tier: "working",
+					strength: 0.8,
+					confidence: 0.8,
+				});
+				const scratchpad = makeEntry({
+					topic: "golang concurrency",
+					content: "goroutines and channels",
+					tier: "scratchpad",
+					strength: 0.8,
+					confidence: 0.8,
+				});
+
+				await manager.upsert(longTerm);
+				await manager.upsert(working);
+				await manager.upsert(scratchpad);
+
+				const results = await manager.search("golang concurrency", 10);
+
+				const ids = results.map((r) => r.id);
+				expect(ids.indexOf(longTerm.id)).toBeLessThan(ids.indexOf(working.id));
+				expect(ids.indexOf(working.id)).toBeLessThan(ids.indexOf(scratchpad.id));
+			});
+
+			it("applies tier multiplier: long-term 1.3x, working 1.0x, scratchpad 0.7x", async () => {
+				// long-term with lower raw score should beat scratchpad with higher raw score
+				// if the tier multiplier compensates
+				const ltEntry = makeEntry({
+					topic: "python testing",
+					content: "pytest fixtures",
+					tier: "long-term",
+					strength: 0.5,  // lower strength
+					confidence: 0.6,
+				});
+				const spEntry = makeEntry({
+					topic: "python testing",
+					content: "pytest fixtures",
+					tier: "scratchpad",
+					strength: 0.5,
+					confidence: 0.6,
+				});
+
+				await manager.upsert(ltEntry);
+				await manager.upsert(spEntry);
+
+				const results = await manager.search("python testing", 10);
+				const ids = results.map((r) => r.id);
+				// long-term should appear before scratchpad
+				expect(ids.indexOf(ltEntry.id)).toBeLessThan(ids.indexOf(spEntry.id));
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// getTierStats
+		// -------------------------------------------------------------------
+
+		describe("getTierStats", () => {
+			it("returns zero counts when store is empty", async () => {
+				const stats = await manager.getTierStats();
+				expect(stats.scratchpad).toBe(0);
+				expect(stats.working).toBe(0);
+				expect(stats.longTerm).toBe(0);
+				expect(stats.total).toBe(0);
+			});
+
+			it("counts entries per tier correctly", async () => {
+				await manager.upsert(makeEntry({ tier: "scratchpad" }));
+				await manager.upsert(makeEntry({ tier: "scratchpad" }));
+				await manager.upsert(makeEntry({ tier: "working" }));
+				await manager.upsert(makeEntry({ tier: "long-term" }));
+
+				const stats = await manager.getTierStats();
+				expect(stats.scratchpad).toBe(2);
+				expect(stats.working).toBe(1);
+				expect(stats.longTerm).toBe(1);
+				expect(stats.total).toBe(4);
+			});
+
+			it("includes entries missing tier field (defaulted to scratchpad) in scratchpad count", async () => {
+				// Write an entry without tier field directly
+				const id = randomUUID();
+				const oldEntry = {
+					id,
+					topic: "tier-less entry",
+					content: "no tier field",
+					source: "taught",
+					createdAt: Date.now(),
+					updatedAt: Date.now(),
+					confidence: 0.8,
+					tags: [],
+					strength: 1.0,
+					lastReferencedAt: Date.now(),
+					referenceCount: 0,
+				};
+				const safeName = id.replace(/[^a-zA-Z0-9_-]/g, "_");
+				await writeFile(
+					join(memoryDir, `${safeName}.json`),
+					JSON.stringify(oldEntry, null, 2),
+					"utf8",
+				);
+
+				const stats = await manager.getTierStats();
+				expect(stats.scratchpad).toBe(1);
+			});
 		});
 	});
 });

--- a/src/memory/knowledge.ts
+++ b/src/memory/knowledge.ts
@@ -6,6 +6,11 @@
  * - strength field tracks knowledge retention (0..1)
  * - Decays over time, reinforced on reference
  * - Weak entries archived to cold storage
+ *
+ * Memory tiering (Issue #42):
+ * - scratchpad: short-lived (TTL-based), immediate storage
+ * - working: mid-term, promoted from scratchpad
+ * - long-term: durable, verified knowledge
  */
 
 import { z } from "zod";
@@ -16,9 +21,46 @@ import {
 	computeReinforcedStrength,
 } from "./decay.js";
 import { FileMemoryStore } from "./store.js";
+import { logger } from "../utils/logger.js";
 
 // Re-export decay multiplier helper for convenience
 export { getDecayMultiplier } from "../expertise/decay.js";
+
+/** Default scratchpad TTL: 1 hour in milliseconds. */
+const DEFAULT_SCRATCHPAD_TTL_MS = 3_600_000;
+
+/** Tier weight multipliers for search scoring. */
+const TIER_MULTIPLIER: Record<string, number> = {
+	"long-term": 1.3,
+	"working": 1.0,
+	"scratchpad": 0.7,
+};
+
+/** Promotion result returned by promoteTiers(). */
+export type TierPromotionResult = {
+	scratchpadToWorking: number;
+	workingToLongTerm: number;
+};
+
+/** Tier statistics returned by getTierStats(). */
+export type TierStats = {
+	scratchpad: number;
+	working: number;
+	longTerm: number;
+	total: number;
+};
+
+/**
+ * Compute the promotion score for a knowledge entry.
+ * promotionScore = referenceCount * 0.4 + confidence * 0.4 + (strength > 0.7 ? 0.2 : 0)
+ */
+function computePromotionScore(
+	referenceCount: number,
+	confidence: number,
+	strength: number,
+): number {
+	return referenceCount * 0.4 + confidence * 0.4 + (strength > 0.7 ? 0.2 : 0);
+}
 
 const KnowledgeEntrySchema = z.object({
 	id: z.string(),
@@ -37,6 +79,17 @@ const KnowledgeEntrySchema = z.object({
 	lastReferencedAt: z.number().default(() => Date.now()),
 	/** Number of times this entry has been referenced. */
 	referenceCount: z.number().int().min(0).default(0),
+	// -----------------------------------------------------------------------
+	// Memory tier fields (Issue #42)
+	// -----------------------------------------------------------------------
+	/** Memory tier: scratchpad (short-lived) → working → long-term. */
+	tier: z.enum(["scratchpad", "working", "long-term"]).default("scratchpad"),
+	/** Timestamp (ms) when the entry last changed tier. */
+	tierCreatedAt: z.number().default(() => Date.now()),
+	/** Promotion score: referenceCount*0.4 + confidence*0.4 + (strength>0.7?0.2:0). */
+	promotionScore: z.number().default(0),
+	/** Custom TTL (ms) for scratchpad entries. Defaults to DEFAULT_SCRATCHPAD_TTL_MS if not set. */
+	scratchpadTtlMs: z.number().optional(),
 });
 
 export type KnowledgeEntry = z.output<typeof KnowledgeEntrySchema>;
@@ -63,10 +116,22 @@ export class KnowledgeManager {
 	}
 
 	/** Store a new knowledge entry or update existing one. */
-	async upsert(entry: Omit<KnowledgeEntry, "updatedAt">): Promise<void> {
+	async upsert(
+		entry: Omit<KnowledgeEntry, "updatedAt" | "tier" | "tierCreatedAt" | "promotionScore"> &
+			Partial<Pick<KnowledgeEntry, "tier" | "tierCreatedAt" | "promotionScore">>,
+	): Promise<void> {
+		const now = Date.now();
 		const withTimestamp: KnowledgeEntry = {
+			tier: "scratchpad",
 			...entry,
-			updatedAt: Date.now(),
+			updatedAt: now,
+			tierCreatedAt: entry.tierCreatedAt ?? now,
+			// Always recompute promotionScore from live field values
+			promotionScore: computePromotionScore(
+				entry.referenceCount,
+				entry.confidence,
+				entry.strength,
+			),
 		};
 		await this.store.write(entry.id, withTimestamp);
 	}
@@ -79,18 +144,26 @@ export class KnowledgeManager {
 	/**
 	 * Reinforce a single knowledge entry — called when it appears in a prompt.
 	 * Increases strength by REINFORCE_DELTA, updates lastReferencedAt,
-	 * increments referenceCount.
+	 * increments referenceCount, and recalculates promotionScore.
 	 */
 	async reinforce(id: string): Promise<void> {
 		const entry = await this.store.read(id);
 		if (!entry) return;
 
+		const newReferenceCount = entry.referenceCount + 1;
+		const newStrength = computeReinforcedStrength(entry.strength);
+
 		const reinforced: KnowledgeEntry = {
 			...entry,
-			strength: computeReinforcedStrength(entry.strength),
+			strength: newStrength,
 			lastReferencedAt: Date.now(),
-			referenceCount: entry.referenceCount + 1,
+			referenceCount: newReferenceCount,
 			updatedAt: Date.now(),
+			promotionScore: computePromotionScore(
+				newReferenceCount,
+				entry.confidence,
+				newStrength,
+			),
 		};
 		await this.store.write(id, reinforced);
 	}
@@ -123,6 +196,11 @@ export class KnowledgeManager {
 					...entry,
 					strength: decayedStrength,
 					updatedAt: Date.now(),
+					promotionScore: computePromotionScore(
+						entry.referenceCount,
+						entry.confidence,
+						decayedStrength,
+					),
 				};
 				await this.store.write(entry.id, updated);
 			}
@@ -166,7 +244,7 @@ export class KnowledgeManager {
 			.slice(0, limit);
 	}
 
-	/** Search knowledge by keyword matching (simple substring search). */
+	/** Search knowledge by keyword matching with tier-priority weighting. */
 	async search(query: string, limit = 10): Promise<KnowledgeEntry[]> {
 		const all = await this.store.readAll();
 		const queryLower = query.toLowerCase();
@@ -174,7 +252,7 @@ export class KnowledgeManager {
 		const scored = all
 			.map(({ value }) => ({
 				entry: value,
-				score: computeRelevance(value, queryLower),
+				score: computeRelevanceWithTier(value, queryLower),
 			}))
 			.filter(
 				({ score, entry }) =>
@@ -199,6 +277,174 @@ export class KnowledgeManager {
 		return all
 			.map((e) => e.value)
 			.filter((e) => e.topic.toLowerCase().trim() === topicLower);
+	}
+
+	// -------------------------------------------------------------------------
+	// Memory tier management (Issue #42)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Expire scratchpad entries whose TTL has elapsed.
+	 * Entries eligible for promotion are promoted instead of deleted.
+	 * @returns Number of entries deleted (not counting promoted ones).
+	 */
+	async expireScratchpad(): Promise<number> {
+		const all = await this.store.readAll();
+		const now = Date.now();
+		let removed = 0;
+
+		for (const { value: entry } of all) {
+			if (entry.tier !== "scratchpad") continue;
+
+			const ttl = entry.scratchpadTtlMs ?? DEFAULT_SCRATCHPAD_TTL_MS;
+			const age = now - entry.tierCreatedAt;
+			if (age <= ttl) continue;
+
+			// Check if eligible for promotion before deleting
+			const eligibleForWorking =
+				entry.referenceCount >= 2 || entry.confidence >= 0.85;
+
+			if (eligibleForWorking) {
+				// Promote to working instead of deleting
+				const promoted: KnowledgeEntry = {
+					...entry,
+					tier: "working",
+					tierCreatedAt: now,
+					updatedAt: now,
+					promotionScore: computePromotionScore(
+						entry.referenceCount,
+						entry.confidence,
+						entry.strength,
+					),
+				};
+				await this.store.write(entry.id, promoted);
+				logger.debug("Scratchpad entry promoted to working (TTL expired)", {
+					id: entry.id,
+					topic: entry.topic,
+				});
+			} else {
+				await this.store.delete(entry.id);
+				removed++;
+				logger.debug("Scratchpad entry expired and deleted", {
+					id: entry.id,
+					topic: entry.topic,
+					ageMs: age,
+				});
+			}
+		}
+
+		return removed;
+	}
+
+	/**
+	 * Evaluate all entries for tier promotion based on promotion rules:
+	 * - scratchpad → working: referenceCount >= 2 OR confidence >= 0.85
+	 * - working → long-term: referenceCount >= 5 AND confidence >= 0.8
+	 * @returns Counts of promotions per tier transition.
+	 */
+	async promoteTiers(): Promise<TierPromotionResult> {
+		const all = await this.store.readAll();
+		const now = Date.now();
+		let scratchpadToWorking = 0;
+		let workingToLongTerm = 0;
+
+		for (const { value: entry } of all) {
+			if (entry.tier === "scratchpad") {
+				const eligible =
+					entry.referenceCount >= 2 || entry.confidence >= 0.85;
+				if (!eligible) continue;
+
+				const promoted: KnowledgeEntry = {
+					...entry,
+					tier: "working",
+					tierCreatedAt: now,
+					updatedAt: now,
+					promotionScore: computePromotionScore(
+						entry.referenceCount,
+						entry.confidence,
+						entry.strength,
+					),
+				};
+				await this.store.write(entry.id, promoted);
+				scratchpadToWorking++;
+				logger.debug("Promoted scratchpad → working", {
+					id: entry.id,
+					topic: entry.topic,
+					referenceCount: entry.referenceCount,
+					confidence: entry.confidence,
+				});
+			} else if (entry.tier === "working") {
+				const eligible =
+					entry.referenceCount >= 5 && entry.confidence >= 0.8;
+				if (!eligible) continue;
+
+				const promoted: KnowledgeEntry = {
+					...entry,
+					tier: "long-term",
+					tierCreatedAt: now,
+					updatedAt: now,
+					promotionScore: computePromotionScore(
+						entry.referenceCount,
+						entry.confidence,
+						entry.strength,
+					),
+				};
+				await this.store.write(entry.id, promoted);
+				workingToLongTerm++;
+				logger.debug("Promoted working → long-term", {
+					id: entry.id,
+					topic: entry.topic,
+					referenceCount: entry.referenceCount,
+					confidence: entry.confidence,
+				});
+			}
+		}
+
+		return { scratchpadToWorking, workingToLongTerm };
+	}
+
+	/**
+	 * Run full tier maintenance cycle:
+	 * 1. Expire TTL-elapsed scratchpad entries (promoting eligible ones)
+	 * 2. Promote entries meeting promotion criteria
+	 * Intended to be called by the memory-tier-maintenance cron job.
+	 */
+	async runTierMaintenance(): Promise<{
+		expired: number;
+		scratchpadToWorking: number;
+		workingToLongTerm: number;
+	}> {
+		const expired = await this.expireScratchpad();
+		const { scratchpadToWorking, workingToLongTerm } = await this.promoteTiers();
+		return { expired, scratchpadToWorking, workingToLongTerm };
+	}
+
+	/**
+	 * Get tier statistics for monitoring and logging.
+	 * @returns Counts of entries per tier and total.
+	 */
+	async getTierStats(): Promise<TierStats> {
+		const all = await this.store.readAll();
+		const stats: TierStats = {
+			scratchpad: 0,
+			working: 0,
+			longTerm: 0,
+			total: 0,
+		};
+
+		for (const { value: entry } of all) {
+			stats.total++;
+			if (entry.tier === "long-term") {
+				stats.longTerm++;
+			} else if (entry.tier === "working") {
+				stats.working++;
+			} else {
+				// "scratchpad" or any defaulted value
+				stats.scratchpad++;
+			}
+		}
+
+		return stats;
 	}
 
 	/**
@@ -235,7 +481,11 @@ function renderStrengthBar(strength: number): string {
 	return `[강도: ${"█".repeat(filled)}${"░".repeat(empty)}]`;
 }
 
-function computeRelevance(entry: KnowledgeEntry, queryLower: string): number {
+/**
+ * Compute relevance score with tier-priority weighting.
+ * Applies tier multipliers: long-term(×1.3), working(×1.0), scratchpad(×0.7)
+ */
+function computeRelevanceWithTier(entry: KnowledgeEntry, queryLower: string): number {
 	let score = 0;
 	const topicLower = entry.topic.toLowerCase();
 	const contentLower = entry.content.toLowerCase();
@@ -250,6 +500,10 @@ function computeRelevance(entry: KnowledgeEntry, queryLower: string): number {
 
 	// Boost by confidence and strength
 	score *= entry.confidence * entry.strength;
+
+	// Apply tier multiplier
+	const tierMultiplier = TIER_MULTIPLIER[entry.tier] ?? 1.0;
+	score *= tierMultiplier;
 
 	return score;
 }

--- a/src/teaching/extractor.ts
+++ b/src/teaching/extractor.ts
@@ -96,6 +96,9 @@ export class KnowledgeExtractor {
 				strength: 1.0,
 				lastReferencedAt: now,
 				referenceCount: 0,
+				tier: "scratchpad",
+				tierCreatedAt: now,
+				promotionScore: 0,
 			};
 
 			await this.knowledge.upsert(entry);


### PR DESCRIPTION
## Summary

- **3-tier 메모리 계층** 도입: `scratchpad` (즉시성, TTL 1h) → `working` (중기) → `long-term` (검증된 지식)
- **승격 규칙 구현**: scratchpad→working (referenceCount≥2 OR confidence≥0.85), working→long-term (referenceCount≥5 AND confidence≥0.8)
- **Retrieval 계층 가중치**: long-term×1.3, working×1.0, scratchpad×0.7
- **매시간 cron job** `memory-tier-maintenance` 추가 — TTL 만료 정리 + 계층 승격 + 통계 로그

## Changes

### `src/memory/knowledge.ts`
- `KnowledgeEntry` 스키마에 `tier`, `tierCreatedAt`, `promotionScore`, `scratchpadTtlMs` 필드 추가 (모두 backward-compatible defaults)
- `expireScratchpad()`: TTL 만료된 scratchpad 항목 삭제, 승격 자격 있으면 working으로 이동
- `promoteTiers()`: 승격 규칙 평가 및 계층 이동, `TierPromotionResult` 반환
- `runTierMaintenance()`: expire + promote 통합 사이클
- `getTierStats()`: 계층별 항목 수 집계 (`TierStats`)
- `search()`: `computeRelevanceWithTier()` 로 tier 가중치 반영
- `upsert()`: tier 필드를 optional로 처리 (backward compatibility)

### `src/cron/jobs.ts`
- `memory-tier-maintenance` job 추가 (매 1시간, `runOnStart: false`)
- 실행 후 tier 통계 로그 출력

### `src/knowledge-feed/subscriber.ts`, `src/teaching/extractor.ts`
- `KnowledgeEntry` 직접 생성 시 새 tier 필드 추가 (tier: "scratchpad", tierCreatedAt: now, promotionScore: 0)

## Test plan

- [x] `npm test -- src/memory/knowledge.test.ts` — 45/45 passed
- [x] `npm run build` — TypeScript 오류 없음
- [ ] 운영 환경에서 `memory-tier-maintenance` cron job 로그 확인
- [ ] 1시간 후 scratchpad TTL 만료 항목 삭제 확인
- [ ] `getTierStats()` 로그를 통해 계층별 항목 수 모니터링

## Closes

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)