### PR TITLE
feat: 2단계 학습 파이프라인 도입 (실시간 추출 + 배치 통합) (#41)

### DIFF
--- a/src/cron/jobs.ts
+++ b/src/cron/jobs.ts
@@ -27,6 +27,8 @@ import type { ReflectionManager } from "../memory/reflection.js";
 import type { RelationshipManager } from "../memory/relationships.js";
 import type { ChannelPlugin } from "../plugins/types.js";
 import type { SessionStore } from "../session/store.js";
+import { BatchIntegrator } from "../teaching/batch-integrator.js";
+import type { StagingQueue } from "../teaching/staging-queue.js";
 import type { GrowthReportConfig } from "../utils/config.js";
 import { logger } from "../utils/logger.js";
 import {
@@ -72,6 +74,11 @@ export type CronJobDeps = {
 	prReview?: PRReviewConfig;
 	/** PR response config for responding to reviews on my PRs. */
 	prResponse?: PRReviewConfig;
+	/**
+	 * Staging queue for two-stage learning pipeline (Issue #41).
+	 * When provided, the batch-integration cron job is registered.
+	 */
+	stagingQueue?: StagingQueue;
 };
 
 const ONE_HOUR = 60 * 60 * 1000;
@@ -206,6 +213,16 @@ export function createBuiltinJobs(deps: CronJobDeps): CronJob[] {
 						intervalMs: deps.prResponse.pollIntervalMs,
 						runOnStart: false,
 						handler: () => runPRResponse(deps.prResponse!),
+					},
+				]
+			: []),
+		...(deps.stagingQueue
+			? [
+					{
+						id: "batch-integration",
+						intervalMs: ONE_HOUR,
+						runOnStart: false,
+						handler: () => runBatchIntegration(deps),
 					},
 				]
 			: []),
@@ -623,6 +640,40 @@ async function runKnowledgeFeedCleanup(
 		});
 		return `지식 피드 정리 완료! 만료된 항목 ${removed}개를 삭제했어요.`;
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Batch integration cron job (Issue #41 — two-stage learning pipeline)
+// ---------------------------------------------------------------------------
+
+/**
+ * Batch integration — Stage 2 of the two-stage learning pipeline.
+ * Reads staged items, applies write gate, promotes approved items to knowledge store.
+ * Runs every hour when a staging queue is configured.
+ */
+async function runBatchIntegration(deps: CronJobDeps): Promise<string | void> {
+	if (!deps.stagingQueue) return;
+
+	const integrator = new BatchIntegrator(deps.stagingQueue, deps.knowledge);
+	const result = await integrator.run();
+
+	if (result.processed === 0) return;
+
+	logger.info("Batch integration completed", {
+		processed: result.processed,
+		approved: result.approved,
+		held: result.held,
+		rejected: result.rejected,
+		deduplicated: result.deduplicated,
+	});
+
+	const parts: string[] = [];
+	if (result.approved > 0) parts.push(`승인 ${result.approved}개`);
+	if (result.held > 0) parts.push(`보류 ${result.held}개`);
+	if (result.rejected > 0) parts.push(`거절 ${result.rejected}개`);
+	if (result.deduplicated > 0) parts.push(`중복 ${result.deduplicated}개`);
+
+	return `배치 통합 완료! ${result.processed}개 처리: ${parts.join(", ")}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/teaching/batch-integrator.test.ts
+++ b/src/teaching/batch-integrator.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Tests for BatchIntegrator — batch processing from staging queue (Issue #41).
+ *
+ * The batch integrator:
+ * 1. Reads pending items from the staging queue
+ * 2. Applies write gate scoring
+ * 3. Promotes approved items to long-term knowledge store
+ * 4. Marks held items for re-evaluation in next batch
+ * 5. Removes rejected/approved items from staging queue
+ * 6. Deduplicates knowledge before storing
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BatchIntegrator } from "./batch-integrator.js";
+import { StagingQueue, type StagedItem } from "./staging-queue.js";
+import { KnowledgeManager } from "../memory/knowledge.js";
+
+function makeTempDir(): string {
+	return join(tmpdir(), `batch-integrator-test-${randomUUID()}`);
+}
+
+function makeStagedItem(overrides: Partial<StagedItem> = {}): StagedItem {
+	const now = Date.now();
+	return {
+		id: randomUUID(),
+		sessionKey: "session-123",
+		userId: "user-abc",
+		type: "explicit",
+		payload: "TypeScript는 JavaScript의 상위 집합이다",
+		confidence: 0.95,
+		extractedAt: now,
+		retryCount: 0,
+		status: "pending",
+		...overrides,
+	};
+}
+
+describe("BatchIntegrator", () => {
+	let queueDir: string;
+	let memoryDir: string;
+	let archiveDir: string;
+	let queue: StagingQueue;
+	let knowledge: KnowledgeManager;
+	let integrator: BatchIntegrator;
+
+	beforeEach(async () => {
+		queueDir = makeTempDir();
+		memoryDir = makeTempDir();
+		archiveDir = join(memoryDir, "..", "archive");
+
+		await mkdir(queueDir, { recursive: true });
+		await mkdir(memoryDir, { recursive: true });
+
+		queue = new StagingQueue(queueDir);
+		knowledge = new KnowledgeManager(memoryDir, archiveDir);
+		integrator = new BatchIntegrator(queue, knowledge);
+	});
+
+	// -------------------------------------------------------------------------
+	// run — core batch processing
+	// -------------------------------------------------------------------------
+
+	describe("run", () => {
+		it("processes pending items and stores approved ones in knowledge", async () => {
+			const item = makeStagedItem({
+				type: "explicit",
+				payload: "Go언어는 구글이 만든 정적 타입 언어다",
+				confidence: 0.95,
+			});
+			await queue.enqueue(item);
+
+			const result = await integrator.run();
+
+			expect(result.approved).toBeGreaterThanOrEqual(1);
+			expect(result.processed).toBeGreaterThanOrEqual(1);
+
+			// The approved item should be in knowledge store
+			const allKnowledge = await knowledge.listAll();
+			expect(allKnowledge.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it("returns zero counts when queue is empty", async () => {
+			const result = await integrator.run();
+
+			expect(result.processed).toBe(0);
+			expect(result.approved).toBe(0);
+			expect(result.held).toBe(0);
+			expect(result.rejected).toBe(0);
+		});
+
+		it("removes approved items from the staging queue after processing", async () => {
+			const item = makeStagedItem({
+				type: "explicit",
+				payload: "React는 Facebook이 만든 UI 라이브러리다",
+				confidence: 0.95,
+			});
+			await queue.enqueue(item);
+
+			await integrator.run();
+
+			// Approved items should be removed from staging queue
+			const pending = await queue.listPending();
+			expect(pending).toHaveLength(0);
+		});
+
+		it("marks rejected items as rejected in staging queue", async () => {
+			const item = makeStagedItem({
+				payload: "ok", // too short to pass gate
+				confidence: 0.3,
+			});
+			await queue.enqueue(item);
+
+			const result = await integrator.run();
+
+			expect(result.rejected).toBeGreaterThanOrEqual(1);
+		});
+
+		it("marks held items as held in staging queue without storing", async () => {
+			// A preference item with moderate confidence should be held
+			const item = makeStagedItem({
+				type: "preference",
+				payload: "좋아하는 것: 피자",
+				confidence: 0.65,
+				retryCount: 0,
+			});
+			await queue.enqueue(item);
+
+			const result = await integrator.run();
+
+			// Either approved or held (depending on gate logic)
+			expect(result.approved + result.held).toBeGreaterThanOrEqual(1);
+		});
+
+		it("logs gate decisions for each processed item", async () => {
+			const item = makeStagedItem({
+				type: "explicit",
+				payload: "Python은 인터프리터 언어다",
+				confidence: 0.9,
+			});
+			await queue.enqueue(item);
+
+			const result = await integrator.run();
+
+			expect(result.gateLog).toBeDefined();
+			expect(result.gateLog.length).toBeGreaterThanOrEqual(1);
+			expect(result.gateLog[0]).toMatchObject({
+				itemId: item.id,
+				decision: expect.stringMatching(/^(approve|hold|reject)$/),
+				score: expect.objectContaining({
+					factuality: expect.any(Number),
+					reusability: expect.any(Number),
+					sensitivity: expect.any(Number),
+					total: expect.any(Number),
+				}),
+			});
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// deduplication
+	// -------------------------------------------------------------------------
+
+	describe("deduplication", () => {
+		it("skips duplicate items already in knowledge store (same topic + similar content)", async () => {
+			// First, store a knowledge entry directly
+			const now = Date.now();
+			await knowledge.upsert({
+				id: randomUUID(),
+				topic: "TypeScript 상위집합",
+				content: "TypeScript는 JavaScript의 상위 집합이다",
+				source: "taught",
+				taughtBy: "user-abc",
+				createdAt: now,
+				updatedAt: now,
+				confidence: 0.9,
+				tags: [],
+				strength: 1.0,
+				lastReferencedAt: now,
+				referenceCount: 0,
+				tier: "scratchpad",
+				tierCreatedAt: now,
+				promotionScore: 0,
+			});
+
+			// Now add the same knowledge to staging queue
+			const duplicate = makeStagedItem({
+				payload: "TypeScript는 JavaScript의 상위 집합이다",
+				confidence: 0.95,
+			});
+			await queue.enqueue(duplicate);
+
+			const result = await integrator.run();
+
+			// Should be detected as duplicate and skipped/rejected
+			expect(result.deduplicated).toBeGreaterThanOrEqual(1);
+			// Knowledge store should still have only 1 entry
+			const allKnowledge = await knowledge.listAll();
+			expect(allKnowledge).toHaveLength(1);
+		});
+
+		it("stores unique items even if similar topics exist", async () => {
+			const now = Date.now();
+			await knowledge.upsert({
+				id: randomUUID(),
+				topic: "TypeScript",
+				content: "TypeScript는 정적 타이핑을 지원한다",
+				source: "taught",
+				taughtBy: "user-abc",
+				createdAt: now,
+				updatedAt: now,
+				confidence: 0.9,
+				tags: [],
+				strength: 1.0,
+				lastReferencedAt: now,
+				referenceCount: 0,
+				tier: "scratchpad",
+				tierCreatedAt: now,
+				promotionScore: 0,
+			});
+
+			// Different content about TypeScript
+			const different = makeStagedItem({
+				payload: "TypeScript는 인터페이스와 제네릭을 지원한다",
+				confidence: 0.95,
+			});
+			await queue.enqueue(different);
+
+			const result = await integrator.run();
+
+			// Should be stored as new knowledge
+			expect(result.approved).toBeGreaterThanOrEqual(1);
+			const allKnowledge = await knowledge.listAll();
+			expect(allKnowledge.length).toBeGreaterThanOrEqual(2);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// held item re-evaluation
+	// -------------------------------------------------------------------------
+
+	describe("held item re-evaluation", () => {
+		it("re-evaluates held items in next batch run", async () => {
+			// Enqueue a held item (simulating it was held in previous batch)
+			const heldItem = makeStagedItem({
+				type: "explicit",
+				payload: "Node.js는 V8 엔진으로 동작하는 JavaScript 런타임이다",
+				confidence: 0.85,
+				status: "held",
+				retryCount: 1,
+			});
+			await queue.enqueue(heldItem);
+
+			const result = await integrator.run();
+
+			// Held item with higher confidence on retry should be approved
+			expect(result.approved + result.held + result.rejected).toBeGreaterThanOrEqual(1);
+		});
+
+		it("increments retryCount when item is held again", async () => {
+			const item = makeStagedItem({
+				type: "preference",
+				payload: "좋아하는 것: 초콜릿",
+				confidence: 0.55,
+				status: "pending",
+				retryCount: 0,
+			});
+			await queue.enqueue(item);
+
+			await integrator.run();
+
+			// Check the item in queue — if held, retryCount should be ≥ 1
+			const held = await queue.listHeld();
+			for (const h of held) {
+				if (h.id === item.id) {
+					expect(h.retryCount).toBeGreaterThanOrEqual(1);
+				}
+			}
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// BatchResult structure
+	// -------------------------------------------------------------------------
+
+	describe("BatchResult", () => {
+		it("returns correct totals", async () => {
+			const good = makeStagedItem({
+				payload: "Docker는 컨테이너 기반 가상화 플랫폼이다",
+				confidence: 0.95,
+			});
+			const bad = makeStagedItem({
+				payload: "ok",
+				confidence: 0.2,
+			});
+
+			await queue.enqueue(good);
+			await queue.enqueue(bad);
+
+			const result = await integrator.run();
+
+			expect(result.processed).toBe(2);
+			expect(result.approved + result.held + result.rejected + result.deduplicated).toBe(2);
+		});
+	});
+});

--- a/src/teaching/batch-integrator.ts
+++ b/src/teaching/batch-integrator.ts
@@ -1,0 +1,233 @@
+/**
+ * Batch integrator — Stage 2 of the two-stage learning pipeline (Issue #41).
+ *
+ * Runs on a periodic cron schedule to:
+ * 1. Pull pending + held items from the staging queue
+ * 2. Apply write gate scoring (factuality / reusability / sensitivity)
+ * 3. Store approved items in the knowledge store (with deduplication)
+ * 4. Re-queue held items (incrementing retryCount)
+ * 5. Remove rejected and approved items from the staging queue
+ * 6. Log all gate decisions for observability
+ *
+ * This keeps expensive integration logic out of the real-time response path.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { KnowledgeManager } from "../memory/knowledge.js";
+import type { KnowledgeEntry } from "../memory/knowledge.js";
+import { logger } from "../utils/logger.js";
+import type { StagedItem } from "./staging-queue.js";
+import { StagingQueue } from "./staging-queue.js";
+import { WriteGate } from "./write-gate.js";
+import type { GateResult } from "./write-gate.js";
+
+export type GateLogEntry = {
+	itemId: string;
+	decision: "approve" | "hold" | "reject";
+	score: GateResult["score"];
+	reason: string;
+};
+
+export type BatchResult = {
+	/** Total items processed in this batch. */
+	processed: number;
+	/** Items approved and stored in knowledge. */
+	approved: number;
+	/** Items held for re-evaluation in next batch. */
+	held: number;
+	/** Items rejected and removed from queue. */
+	rejected: number;
+	/** Items skipped as duplicates of existing knowledge. */
+	deduplicated: number;
+	/** Per-item gate decision log. */
+	gateLog: GateLogEntry[];
+};
+
+/** Word-overlap similarity (Jaccard index). */
+function similarity(a: string, b: string): number {
+	const wordsA = new Set(a.toLowerCase().split(/\s+/));
+	const wordsB = new Set(b.toLowerCase().split(/\s+/));
+	const intersection = [...wordsA].filter((w) => wordsB.has(w)).length;
+	const union = new Set([...wordsA, ...wordsB]).size;
+	return union === 0 ? 0 : intersection / union;
+}
+
+/** Extract a short topic from the payload text (first clause, max 50 chars). */
+function extractTopic(text: string): string {
+	const firstClause = text.split(/[,.;:!?]/)[0] ?? text;
+	return firstClause.slice(0, 50).trim();
+}
+
+export class BatchIntegrator {
+	private readonly gate: WriteGate;
+
+	constructor(
+		private readonly queue: StagingQueue,
+		private readonly knowledge: KnowledgeManager,
+	) {
+		this.gate = new WriteGate();
+	}
+
+	/**
+	 * Run one batch integration cycle.
+	 * Processes both pending and held items.
+	 *
+	 * @returns Summary of what happened during this batch.
+	 */
+	async run(): Promise<BatchResult> {
+		const result: BatchResult = {
+			processed: 0,
+			approved: 0,
+			held: 0,
+			rejected: 0,
+			deduplicated: 0,
+			gateLog: [],
+		};
+
+		// Collect pending + held items for this batch
+		const [pendingItems, heldItems] = await Promise.all([
+			this.queue.listPending(),
+			this.queue.listHeld(),
+		]);
+		const items = [...pendingItems, ...heldItems];
+
+		if (items.length === 0) {
+			logger.debug("Batch integrator: no items to process");
+			return result;
+		}
+
+		logger.info("Batch integrator: starting batch", {
+			pending: pendingItems.length,
+			held: heldItems.length,
+		});
+
+		for (const item of items) {
+			result.processed++;
+
+			const { result: gateResult } = this.gate.evaluateMany([item])[0]!;
+
+			// Log gate decision
+			const logEntry: GateLogEntry = {
+				itemId: item.id,
+				decision: gateResult.decision,
+				score: gateResult.score,
+				reason: gateResult.reason,
+			};
+			result.gateLog.push(logEntry);
+
+			logger.info("Batch integrator: gate decision", {
+				itemId: item.id,
+				decision: gateResult.decision,
+				total: gateResult.score.total.toFixed(3),
+				reason: gateResult.reason,
+			});
+
+			switch (gateResult.decision) {
+				case "approve": {
+					const isDuplicate = await this.checkDuplicate(item);
+					if (isDuplicate) {
+						result.deduplicated++;
+						await this.queue.remove(item.id);
+						logger.debug("Batch integrator: deduped item", {
+							itemId: item.id,
+							payload: item.payload.slice(0, 60),
+						});
+					} else {
+						await this.storeKnowledge(item);
+						await this.queue.remove(item.id);
+						result.approved++;
+					}
+					break;
+				}
+
+				case "hold": {
+					// Mark as held for re-evaluation in next batch
+					await this.queue.updateStatus(
+						item.id,
+						"held",
+						gateResult.reason,
+					);
+					result.held++;
+					logger.debug("Batch integrator: item held for re-evaluation", {
+						itemId: item.id,
+						retryCount: item.retryCount,
+					});
+					break;
+				}
+
+				case "reject": {
+					await this.queue.updateStatus(
+						item.id,
+						"rejected",
+						gateResult.reason,
+					);
+					result.rejected++;
+					logger.debug("Batch integrator: item rejected", {
+						itemId: item.id,
+						reason: gateResult.reason,
+					});
+					break;
+				}
+			}
+		}
+
+		logger.info("Batch integrator: batch complete", {
+			processed: result.processed,
+			approved: result.approved,
+			held: result.held,
+			rejected: result.rejected,
+			deduplicated: result.deduplicated,
+		});
+
+		return result;
+	}
+
+	/**
+	 * Check whether an item is a near-duplicate of existing knowledge.
+	 * Uses topic extraction + Jaccard similarity on content.
+	 */
+	private async checkDuplicate(item: StagedItem): Promise<boolean> {
+		const topic = extractTopic(item.payload);
+		const existing = await this.knowledge.search(topic, 5);
+
+		return existing.some(
+			(e) =>
+				e.topic === topic ||
+				similarity(e.content, item.payload) > 0.75,
+		);
+	}
+
+	/**
+	 * Convert a staged item to a KnowledgeEntry and upsert it.
+	 */
+	private async storeKnowledge(item: StagedItem): Promise<void> {
+		const now = Date.now();
+		const topic = extractTopic(item.payload);
+
+		const entry: KnowledgeEntry = {
+			id: randomUUID(),
+			topic,
+			content: item.payload,
+			source: item.type === "correction" ? "corrected" : "taught",
+			taughtBy: item.userId,
+			createdAt: now,
+			updatedAt: now,
+			confidence: item.confidence,
+			tags: [],
+			strength: 1.0,
+			lastReferencedAt: now,
+			referenceCount: 0,
+			tier: "scratchpad",
+			tierCreatedAt: now,
+			promotionScore: 0,
+		};
+
+		await this.knowledge.upsert(entry);
+
+		logger.debug("Batch integrator: knowledge stored", {
+			topic,
+			source: entry.source,
+			confidence: entry.confidence,
+		});
+	}
+}

--- a/src/teaching/extractor.ts
+++ b/src/teaching/extractor.ts
@@ -1,8 +1,13 @@
 /**
  * Knowledge extractor — converts detected teaching into structured knowledge.
  *
- * For explicit and correction intents, extracts topic + content directly.
- * For preference intents, routes to relationship manager instead.
+ * Two-stage pipeline (Issue #41):
+ * - If a StagingQueue is provided, items are written to the staging queue for
+ *   batch processing by BatchIntegrator (recommended path).
+ * - Without a staging queue (legacy), items are stored directly in the
+ *   knowledge store (original behaviour, kept for backward compatibility).
+ *
+ * For preference intents, routes to relationship manager instead of knowledge.
  */
 
 import { randomUUID } from "node:crypto";
@@ -12,10 +17,13 @@ import type { KnowledgeManager } from "../memory/knowledge.js";
 import type { RelationshipManager } from "../memory/relationships.js";
 import { logger } from "../utils/logger.js";
 import type { TeachingIntent } from "./detector.js";
+import type { StagingQueue } from "./staging-queue.js";
 
 export type ExtractionResult = {
 	stored: number;
 	skipped: number;
+	/** Number of items enqueued to the staging queue (two-stage pipeline). */
+	staged: number;
 	entries: KnowledgeEntry[];
 };
 
@@ -24,12 +32,92 @@ export class KnowledgeExtractor {
 		private readonly knowledge: KnowledgeManager,
 		private readonly relationships: RelationshipManager,
 		private readonly feedPublisher?: FeedPublisher,
+		/** Optional staging queue for the two-stage pipeline (Issue #41). */
+		private readonly stagingQueue?: StagingQueue,
 	) {}
 
 	/**
-	 * Process detected teaching intents and store as knowledge/preferences.
+	 * Process detected teaching intents.
+	 *
+	 * Two-stage mode (stagingQueue provided):
+	 *   - Preferences go to relationship manager immediately.
+	 *   - All other intents are enqueued in the staging queue.
+	 *   - Returns staged count; knowledge store is NOT written yet.
+	 *
+	 * Legacy mode (no stagingQueue):
+	 *   - Original behaviour: intents written directly to knowledge store.
 	 */
 	async extract(
+		intents: TeachingIntent[],
+		userId: string,
+		sessionKey?: string,
+	): Promise<ExtractionResult> {
+		if (this.stagingQueue) {
+			return this.extractToStaging(intents, userId, sessionKey ?? "");
+		}
+		return this.extractDirect(intents, userId);
+	}
+
+	// -------------------------------------------------------------------------
+	// Two-stage path: enqueue to staging queue
+	// -------------------------------------------------------------------------
+
+	private async extractToStaging(
+		intents: TeachingIntent[],
+		userId: string,
+		sessionKey: string,
+	): Promise<ExtractionResult> {
+		let staged = 0;
+		let skipped = 0;
+		const entries: KnowledgeEntry[] = [];
+
+		for (const intent of intents) {
+			if (intent.confidence < 0.5) {
+				skipped++;
+				continue;
+			}
+
+			if (intent.type === "preference") {
+				// Preferences still go directly to relationship manager
+				await this.relationships.addPreference(userId, intent.payload);
+				logger.info("Preference stored (staging path)", {
+					userId,
+					payload: intent.payload,
+				});
+				staged++;
+				continue;
+			}
+
+			// Enqueue to staging queue — no heavy integration here
+			await this.stagingQueue!.enqueue({
+				id: randomUUID(),
+				sessionKey,
+				userId,
+				type: intent.type,
+				payload: intent.payload,
+				confidence: intent.confidence,
+				extractedAt: Date.now(),
+				retryCount: 0,
+				status: "pending",
+			});
+
+			logger.info("Knowledge enqueued to staging queue", {
+				sessionKey,
+				type: intent.type,
+				payload: intent.payload.slice(0, 80),
+			});
+
+			staged++;
+		}
+
+		return { stored: 0, skipped, staged, entries };
+	}
+
+	// -------------------------------------------------------------------------
+	// Legacy path: write directly to knowledge store
+	// -------------------------------------------------------------------------
+
+	private async extractDirect(
 		intents: TeachingIntent[],
 		userId: string,
 	): Promise<ExtractionResult> {
@@ -119,11 +207,10 @@ export class KnowledgeExtractor {
 				});
 			}
 
-
 			stored++;
 		}
 
-		return { stored, skipped, entries };
+		return { stored, skipped, staged: 0, entries };
 	}
 }
 

--- a/src/teaching/integrator.ts
+++ b/src/teaching/integrator.ts
@@ -1,8 +1,13 @@
 /**
- * Session-end integrator — runs after each session to:
- * 1. Detect any unprocessed teachings from the conversation
- * 2. Generate a session reflection
+ * Session-end integrator — Stage 1 of the two-stage learning pipeline (Issue #41).
+ *
+ * Runs after each session to:
+ * 1. Detect unprocessed teachings and enqueue them to the staging queue
+ * 2. Generate a lightweight session reflection (still uses Claude)
  * 3. Update relationship notes
+ *
+ * Heavy integration (dedup, conflict resolution, write gate) is deferred to
+ * BatchIntegrator which runs on a cron schedule (Stage 2).
  *
  * Reference: OpenClaw memory-core dreaming pattern (extraction → consolidation → narrative)
  */
@@ -17,10 +22,13 @@ import type { RelationshipManager } from "../memory/relationships.js";
 import { logger } from "../utils/logger.js";
 import { detectTeaching } from "./detector.js";
 import { KnowledgeExtractor } from "./extractor.js";
+import type { StagingQueue } from "./staging-queue.js";
 
 export type IntegrationResult = {
 	reflection: Reflection | null;
 	knowledgeStored: number;
+	/** Number of items enqueued to staging queue (two-stage pipeline). */
+	knowledgeStaged: number;
 	notesAdded: number;
 };
 
@@ -32,16 +40,26 @@ export class SessionIntegrator {
 		private readonly reflections: ReflectionManager,
 		private readonly relationships: RelationshipManager,
 		feedPublisher?: FeedPublisher,
+		/** Optional staging queue — enables two-stage pipeline (Issue #41). */
+		stagingQueue?: StagingQueue,
 	) {
 		this.extractor = new KnowledgeExtractor(
 			knowledge,
 			relationships,
 			feedPublisher,
+			stagingQueue,
 		);
 	}
 
 	/**
 	 * Process a completed session. Should be called after session ends.
+	 *
+	 * Stage 1 (real-time, lightweight):
+	 * - Detects teaching intents and enqueues them to the staging queue.
+	 * - Generates a reflection (still uses Claude for context continuity).
+	 * - Updates relationship notes.
+	 *
+	 * Heavy dedup/conflict/gate logic is deferred to BatchIntegrator (Stage 2).
 	 * This is fire-and-forget — failures are logged but don't propagate.
 	 */
 	async integrate(
@@ -50,15 +68,22 @@ export class SessionIntegrator {
 		conversationSummary: string,
 	): Promise<IntegrationResult> {
 		let knowledgeStored = 0;
+		let knowledgeStaged = 0;
 		let notesAdded = 0;
 		let reflection: Reflection | null = null;
 
 		try {
 			// 1. Scan conversation for missed teaching intents
+			//    Two-stage: enqueue to staging queue instead of direct storage
 			const intents = detectTeaching(conversationSummary);
 			if (intents.length > 0) {
-				const result = await this.extractor.extract(intents, userId);
+				const result = await this.extractor.extract(
+					intents,
+					userId,
+					sessionKey,
+				);
 				knowledgeStored = result.stored;
+				knowledgeStaged = result.staged;
 			}
 
 			// 2. Generate session reflection via Claude
@@ -80,9 +105,10 @@ export class SessionIntegrator {
 				}
 			}
 
-			logger.info("Session integration complete", {
+			logger.info("Session integration complete (stage 1)", {
 				sessionKey,
 				knowledgeStored,
+				knowledgeStaged,
 				notesAdded,
 				hasReflection: !!reflection,
 			});
@@ -93,7 +119,7 @@ export class SessionIntegrator {
 			});
 		}
 
-		return { reflection, knowledgeStored, notesAdded };
+		return { reflection, knowledgeStored, knowledgeStaged, notesAdded };
 	}
 
 	/**

--- a/src/teaching/staging-queue.test.ts
+++ b/src/teaching/staging-queue.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for StagingQueue — two-stage learning pipeline (Issue #41).
+ *
+ * The staging queue holds extracted knowledge before batch integration.
+ * Items are stored as JSON and can be listed, consumed, and expired.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import { StagingQueue, type StagedItem } from "./staging-queue.js";
+
+function makeTempDir(): string {
+	return join(tmpdir(), `staging-queue-test-${randomUUID()}`);
+}
+
+function makeStagedItem(overrides: Partial<StagedItem> = {}): StagedItem {
+	const now = Date.now();
+	return {
+		id: randomUUID(),
+		sessionKey: "session-123",
+		userId: "user-abc",
+		type: "explicit",
+		payload: "좋아하는 음식은 피자야",
+		confidence: 0.95,
+		extractedAt: now,
+		retryCount: 0,
+		status: "pending",
+		...overrides,
+	};
+}
+
+describe("StagingQueue", () => {
+	let queueDir: string;
+	let queue: StagingQueue;
+
+	beforeEach(async () => {
+		queueDir = makeTempDir();
+		await mkdir(queueDir, { recursive: true });
+		queue = new StagingQueue(queueDir);
+	});
+
+	// -------------------------------------------------------------------------
+	// enqueue
+	// -------------------------------------------------------------------------
+
+	describe("enqueue", () => {
+		it("stores a staged item and returns it", async () => {
+			const item = makeStagedItem();
+			const stored = await queue.enqueue(item);
+
+			expect(stored.id).toBe(item.id);
+			expect(stored.status).toBe("pending");
+		});
+
+		it("persists item so it can be retrieved", async () => {
+			const item = makeStagedItem();
+			await queue.enqueue(item);
+
+			const retrieved = await queue.get(item.id);
+			expect(retrieved).not.toBeNull();
+			expect(retrieved?.payload).toBe(item.payload);
+		});
+
+		it("assigns extractedAt if not provided", async () => {
+			const item = makeStagedItem({ extractedAt: 0 });
+			const before = Date.now();
+			await queue.enqueue(item);
+			const after = Date.now();
+
+			const retrieved = await queue.get(item.id);
+			expect(retrieved?.extractedAt).toBeGreaterThanOrEqual(before);
+			expect(retrieved?.extractedAt).toBeLessThanOrEqual(after);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// listPending
+	// -------------------------------------------------------------------------
+
+	describe("listPending", () => {
+		it("returns only pending items", async () => {
+			const pending1 = makeStagedItem({ status: "pending" });
+			const pending2 = makeStagedItem({ status: "pending" });
+			const approved = makeStagedItem({ status: "approved" });
+			const rejected = makeStagedItem({ status: "rejected" });
+			const held = makeStagedItem({ status: "held" });
+
+			await queue.enqueue(pending1);
+			await queue.enqueue(pending2);
+			await queue.enqueue(approved);
+			await queue.enqueue(rejected);
+			await queue.enqueue(held);
+
+			const result = await queue.listPending();
+			expect(result).toHaveLength(2);
+			const ids = result.map((r) => r.id);
+			expect(ids).toContain(pending1.id);
+			expect(ids).toContain(pending2.id);
+		});
+
+		it("returns empty array when no pending items", async () => {
+			const result = await queue.listPending();
+			expect(result).toHaveLength(0);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// listHeld
+	// -------------------------------------------------------------------------
+
+	describe("listHeld", () => {
+		it("returns only held items", async () => {
+			const held = makeStagedItem({ status: "held" });
+			const pending = makeStagedItem({ status: "pending" });
+
+			await queue.enqueue(held);
+			await queue.enqueue(pending);
+
+			const result = await queue.listHeld();
+			expect(result).toHaveLength(1);
+			expect(result[0]?.id).toBe(held.id);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// updateStatus
+	// -------------------------------------------------------------------------
+
+	describe("updateStatus", () => {
+		it("updates item status to approved", async () => {
+			const item = makeStagedItem();
+			await queue.enqueue(item);
+
+			await queue.updateStatus(item.id, "approved");
+
+			const retrieved = await queue.get(item.id);
+			expect(retrieved?.status).toBe("approved");
+		});
+
+		it("updates item status to rejected", async () => {
+			const item = makeStagedItem();
+			await queue.enqueue(item);
+
+			await queue.updateStatus(item.id, "rejected");
+
+			const retrieved = await queue.get(item.id);
+			expect(retrieved?.status).toBe("rejected");
+		});
+
+		it("updates item status to held with reason", async () => {
+			const item = makeStagedItem();
+			await queue.enqueue(item);
+
+			await queue.updateStatus(item.id, "held", "Low reusability score");
+
+			const retrieved = await queue.get(item.id);
+			expect(retrieved?.status).toBe("held");
+			expect(retrieved?.gateReason).toBe("Low reusability score");
+		});
+
+		it("increments retryCount when transitioning from held to pending", async () => {
+			const item = makeStagedItem({ status: "held", retryCount: 1 });
+			await queue.enqueue(item);
+
+			await queue.updateStatus(item.id, "pending");
+
+			const retrieved = await queue.get(item.id);
+			expect(retrieved?.retryCount).toBe(2);
+		});
+
+		it("is no-op for nonexistent id", async () => {
+			await expect(
+				queue.updateStatus("nonexistent-id", "approved"),
+			).resolves.not.toThrow();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// remove
+	// -------------------------------------------------------------------------
+
+	describe("remove", () => {
+		it("removes an item from the queue", async () => {
+			const item = makeStagedItem();
+			await queue.enqueue(item);
+
+			await queue.remove(item.id);
+
+			const retrieved = await queue.get(item.id);
+			expect(retrieved).toBeNull();
+		});
+
+		it("does not throw when removing nonexistent item", async () => {
+			await expect(queue.remove("nonexistent-id")).resolves.not.toThrow();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// expireOld
+	// -------------------------------------------------------------------------
+
+	describe("expireOld", () => {
+		it("removes items older than TTL", async () => {
+			const old = makeStagedItem({
+				extractedAt: Date.now() - 2 * 24 * 60 * 60 * 1000, // 2 days ago
+				status: "pending",
+			});
+			const fresh = makeStagedItem({
+				extractedAt: Date.now() - 1_000, // 1 second ago
+				status: "pending",
+			});
+
+			await queue.enqueue(old);
+			await queue.enqueue(fresh);
+
+			const removed = await queue.expireOld(24 * 60 * 60 * 1000); // 1 day TTL
+
+			expect(removed).toBe(1);
+			expect(await queue.get(old.id)).toBeNull();
+			expect(await queue.get(fresh.id)).not.toBeNull();
+		});
+
+		it("does not expire held items waiting for re-evaluation", async () => {
+			const heldOld = makeStagedItem({
+				extractedAt: Date.now() - 2 * 24 * 60 * 60 * 1000,
+				status: "held",
+			});
+			await queue.enqueue(heldOld);
+
+			const removed = await queue.expireOld(24 * 60 * 60 * 1000);
+
+			// held items are preserved for re-evaluation in next batch
+			expect(removed).toBe(0);
+			expect(await queue.get(heldOld.id)).not.toBeNull();
+		});
+
+		it("returns 0 when no items to expire", async () => {
+			const removed = await queue.expireOld(24 * 60 * 60 * 1000);
+			expect(removed).toBe(0);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// size
+	// -------------------------------------------------------------------------
+
+	describe("size", () => {
+		it("returns total number of items in queue", async () => {
+			expect(await queue.size()).toBe(0);
+
+			await queue.enqueue(makeStagedItem());
+			await queue.enqueue(makeStagedItem());
+
+			expect(await queue.size()).toBe(2);
+		});
+	});
+});

--- a/src/teaching/staging-queue.ts
+++ b/src/teaching/staging-queue.ts
@@ -1,0 +1,143 @@
+/**
+ * Staging queue for the two-stage learning pipeline (Issue #41).
+ *
+ * Stage 1 (real-time): Session-end extraction stores items here as lightweight JSON.
+ * Stage 2 (batch):     Cron job reads from here, applies write gate, promotes to
+ *                      long-term knowledge store.
+ *
+ * This decouples expensive integration logic from the response path.
+ */
+
+import { z } from "zod";
+import { FileMemoryStore } from "../memory/store.js";
+
+export const StagedItemSchema = z.object({
+	/** Unique item ID. */
+	id: z.string(),
+	/** Source session key. */
+	sessionKey: z.string(),
+	/** User who provided the teaching. */
+	userId: z.string(),
+	/** Teaching intent type. */
+	type: z.enum(["explicit", "correction", "preference"]),
+	/** Raw extracted payload. */
+	payload: z.string(),
+	/** Confidence from the detector (0-1). */
+	confidence: z.number().min(0).max(1),
+	/** Timestamp when this item was extracted. */
+	extractedAt: z.number().default(() => Date.now()),
+	/** Number of times this item has been evaluated (held → pending cycles). */
+	retryCount: z.number().int().min(0).default(0),
+	/**
+	 * Lifecycle status:
+	 * - pending:  waiting to be evaluated by the write gate
+	 * - approved: gate approved, will be promoted to knowledge store
+	 * - held:     gate held for re-evaluation in next batch
+	 * - rejected: gate rejected, will not be stored
+	 */
+	status: z.enum(["pending", "approved", "held", "rejected"]).default("pending"),
+	/** Optional reason from the gate for hold/reject decisions. */
+	gateReason: z.string().optional(),
+});
+
+export type StagedItem = z.output<typeof StagedItemSchema>;
+
+export class StagingQueue {
+	private readonly store: FileMemoryStore<typeof StagedItemSchema>;
+
+	constructor(queueDir: string) {
+		this.store = new FileMemoryStore(queueDir, StagedItemSchema);
+	}
+
+	/**
+	 * Add a new item to the staging queue.
+	 * Sets extractedAt to now if zero/falsy.
+	 */
+	async enqueue(item: StagedItem): Promise<StagedItem> {
+		const stored: StagedItem = {
+			...item,
+			extractedAt: item.extractedAt || Date.now(),
+		};
+		await this.store.write(item.id, stored);
+		return stored;
+	}
+
+	/** Retrieve a single item by ID. Returns null if not found. */
+	async get(id: string): Promise<StagedItem | null> {
+		return this.store.read(id);
+	}
+
+	/** List all items with status = 'pending'. */
+	async listPending(): Promise<StagedItem[]> {
+		const all = await this.store.readAll();
+		return all.map((e) => e.value).filter((item) => item.status === "pending");
+	}
+
+	/** List all items with status = 'held' (awaiting re-evaluation). */
+	async listHeld(): Promise<StagedItem[]> {
+		const all = await this.store.readAll();
+		return all.map((e) => e.value).filter((item) => item.status === "held");
+	}
+
+	/**
+	 * Update the status of an item.
+	 * When transitioning from held → pending, increments retryCount.
+	 */
+	async updateStatus(
+		id: string,
+		status: StagedItem["status"],
+		reason?: string,
+	): Promise<void> {
+		const item = await this.store.read(id);
+		if (!item) return;
+
+		const wasHeld = item.status === "held";
+		const transitioningToPending = status === "pending";
+
+		const updated: StagedItem = {
+			...item,
+			status,
+			gateReason: reason ?? item.gateReason,
+			retryCount:
+				wasHeld && transitioningToPending
+					? item.retryCount + 1
+					: item.retryCount,
+		};
+
+		await this.store.write(id, updated);
+	}
+
+	/** Remove an item from the queue entirely. */
+	async remove(id: string): Promise<void> {
+		await this.store.delete(id);
+	}
+
+	/**
+	 * Expire and remove items older than the given TTL (in ms).
+	 * Held items are preserved — they are awaiting re-evaluation.
+	 * @returns Number of items removed.
+	 */
+	async expireOld(ttlMs: number): Promise<number> {
+		const all = await this.store.readAll();
+		const cutoff = Date.now() - ttlMs;
+		let removed = 0;
+
+		for (const { value: item } of all) {
+			// Preserve held items for re-evaluation
+			if (item.status === "held") continue;
+
+			if (item.extractedAt < cutoff) {
+				await this.store.delete(item.id);
+				removed++;
+			}
+		}
+
+		return removed;
+	}
+
+	/** Returns the total number of items in the queue (all statuses). */
+	async size(): Promise<number> {
+		const all = await this.store.readAll();
+		return all.length;
+	}
+}

--- a/src/teaching/write-gate.test.ts
+++ b/src/teaching/write-gate.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for WriteGate — gate decision scoring before long-term storage (Issue #41).
+ *
+ * The write gate evaluates staged items for:
+ * - Factuality: is the payload verifiable / not speculative?
+ * - Reusability: will this be referenced across sessions?
+ * - Sensitivity: does it contain personal or sensitive data?
+ *
+ * Decision: approve / hold / reject based on composite score.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	WriteGate,
+	type GateDecision,
+	type GateScore,
+} from "./write-gate.js";
+import type { StagedItem } from "./staging-queue.js";
+import { randomUUID } from "node:crypto";
+
+function makeStagedItem(overrides: Partial<StagedItem> = {}): StagedItem {
+	const now = Date.now();
+	return {
+		id: randomUUID(),
+		sessionKey: "session-123",
+		userId: "user-abc",
+		type: "explicit",
+		payload: "TypeScript는 JavaScript의 상위 집합이야",
+		confidence: 0.95,
+		extractedAt: now,
+		retryCount: 0,
+		status: "pending",
+		...overrides,
+	};
+}
+
+describe("WriteGate", () => {
+	const gate = new WriteGate();
+
+	// -------------------------------------------------------------------------
+	// evaluate — basic decision logic
+	// -------------------------------------------------------------------------
+
+	describe("evaluate", () => {
+		it("returns approve for high-quality factual knowledge", () => {
+			const item = makeStagedItem({
+				type: "explicit",
+				payload: "TypeScript는 JavaScript의 상위 집합이다",
+				confidence: 0.95,
+			});
+
+			const result = gate.evaluate(item);
+
+			expect(result.decision).toBe("approve");
+			expect(result.score.total).toBeGreaterThan(0.6);
+		});
+
+		it("returns reject for very short or empty payload", () => {
+			const item = makeStagedItem({
+				payload: "ok",
+				confidence: 0.5,
+			});
+
+			const result = gate.evaluate(item);
+
+			expect(result.decision).toBe("reject");
+		});
+
+		it("returns reject for low confidence items", () => {
+			const item = makeStagedItem({
+				payload: "아마도 그럴지도 모르겠어 어쩌면 가능성이 있을 것 같기도 해",
+				confidence: 0.3,
+			});
+
+			const result = gate.evaluate(item);
+
+			expect(result.decision).not.toBe("approve");
+		});
+
+		it("returns hold for medium-confidence items", () => {
+			const item = makeStagedItem({
+				type: "preference",
+				payload: "좋아하는 것: 커피",
+				confidence: 0.65,
+				retryCount: 0,
+			});
+
+			const result = gate.evaluate(item);
+
+			// Preference with moderate confidence — may hold for review
+			expect(["hold", "approve"]).toContain(result.decision);
+		});
+
+		it("rejects items with sensitive data patterns", () => {
+			const item = makeStagedItem({
+				payload: "내 비밀번호는 abc123 이야",
+				confidence: 0.9,
+			});
+
+			const result = gate.evaluate(item);
+
+			expect(result.decision).toBe("reject");
+			expect(result.reason).toContain("민감");
+		});
+
+		it("rejects items with phone number patterns", () => {
+			const item = makeStagedItem({
+				payload: "내 전화번호는 010-1234-5678 이야",
+				confidence: 0.9,
+			});
+
+			const result = gate.evaluate(item);
+
+			expect(result.decision).toBe("reject");
+		});
+
+		it("rejects items with email patterns", () => {
+			const item = makeStagedItem({
+				payload: "내 이메일은 test@example.com 이야",
+				confidence: 0.9,
+			});
+
+			const result = gate.evaluate(item);
+
+			expect(result.decision).toBe("reject");
+		});
+
+		it("approves correction type with high confidence", () => {
+			const item = makeStagedItem({
+				type: "correction",
+				payload: "JavaScript에서 == 대신 === 를 써야 한다",
+				confidence: 0.95,
+			});
+
+			const result = gate.evaluate(item);
+
+			expect(result.decision).toBe("approve");
+		});
+
+		it("includes gate log with scores", () => {
+			const item = makeStagedItem();
+			const result = gate.evaluate(item);
+
+			expect(result.score).toBeDefined();
+			expect(result.score.factuality).toBeGreaterThanOrEqual(0);
+			expect(result.score.factuality).toBeLessThanOrEqual(1);
+			expect(result.score.reusability).toBeGreaterThanOrEqual(0);
+			expect(result.score.reusability).toBeLessThanOrEqual(1);
+			expect(result.score.sensitivity).toBeGreaterThanOrEqual(0);
+			expect(result.score.sensitivity).toBeLessThanOrEqual(1);
+			expect(result.score.total).toBeGreaterThanOrEqual(0);
+			expect(result.score.total).toBeLessThanOrEqual(1);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// evaluateMany
+	// -------------------------------------------------------------------------
+
+	describe("evaluateMany", () => {
+		it("evaluates multiple items and returns decisions for each", () => {
+			const items = [
+				makeStagedItem({ payload: "ok" }), // short — reject
+				makeStagedItem({
+					type: "explicit",
+					payload: "React는 Facebook이 만든 UI 라이브러리다",
+					confidence: 0.9,
+				}), // good — approve
+			];
+
+			const results = gate.evaluateMany(items);
+
+			expect(results).toHaveLength(2);
+			expect(results[0]?.result.decision).toBe("reject");
+			expect(results[1]?.result.decision).toBe("approve");
+		});
+
+		it("returns empty array for empty input", () => {
+			const results = gate.evaluateMany([]);
+			expect(results).toHaveLength(0);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// held item re-evaluation policy
+	// -------------------------------------------------------------------------
+
+	describe("held item re-evaluation", () => {
+		it("promotes held item to approve after retryCount >= 1 if score improves", () => {
+			// An item that was previously held but has been seen again (retryCount=1)
+			// and has higher confidence this time
+			const item = makeStagedItem({
+				type: "explicit",
+				payload: "Go언어는 구글이 만든 정적 타입 언어다",
+				confidence: 0.85,
+				status: "held",
+				retryCount: 1,
+			});
+
+			const result = gate.evaluate(item);
+
+			// With confidence 0.85 and retryCount 1, should approve
+			expect(result.decision).toBe("approve");
+		});
+
+		it("rejects held item after maxRetries exceeded", () => {
+			const item = makeStagedItem({
+				payload: "짧아", // low quality
+				confidence: 0.5,
+				status: "held",
+				retryCount: 3, // exceeded max retries
+			});
+
+			const result = gate.evaluate(item);
+
+			expect(result.decision).toBe("reject");
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// GateScore structure
+	// -------------------------------------------------------------------------
+
+	describe("GateScore", () => {
+		it("factuality is higher for objective statements", () => {
+			const objective = makeStagedItem({
+				payload: "Python은 인터프리터 언어이며 동적 타이핑을 사용한다",
+				confidence: 0.9,
+			});
+			const speculative = makeStagedItem({
+				payload: "아마도 가능한지도 모르겠어 어쩌면 그럴 것 같기도 하고",
+				confidence: 0.9,
+			});
+
+			const objResult = gate.evaluate(objective);
+			const specResult = gate.evaluate(speculative);
+
+			expect(objResult.score.factuality).toBeGreaterThan(
+				specResult.score.factuality,
+			);
+		});
+
+		it("reusability is higher for general facts than personal preferences", () => {
+			const fact = makeStagedItem({
+				type: "explicit",
+				payload: "Node.js는 V8 엔진 위에서 동작하는 JavaScript 런타임이다",
+				confidence: 0.9,
+			});
+			const preference = makeStagedItem({
+				type: "preference",
+				payload: "좋아하는 것: 커피",
+				confidence: 0.9,
+			});
+
+			const factResult = gate.evaluate(fact);
+			const prefResult = gate.evaluate(preference);
+
+			expect(factResult.score.reusability).toBeGreaterThanOrEqual(
+				prefResult.score.reusability,
+			);
+		});
+
+		it("sensitivity is higher (worse) for items containing PII patterns", () => {
+			const safe = makeStagedItem({
+				payload: "JavaScript에서 클로저는 외부 변수를 캡처한다",
+				confidence: 0.9,
+			});
+			const sensitive = makeStagedItem({
+				payload: "내 계좌번호는 1234-5678-9012야",
+				confidence: 0.9,
+			});
+
+			const safeResult = gate.evaluate(safe);
+			const sensitiveResult = gate.evaluate(sensitive);
+
+			expect(sensitiveResult.score.sensitivity).toBeGreaterThan(
+				safeResult.score.sensitivity,
+			);
+		});
+	});
+});

--- a/src/teaching/write-gate.ts
+++ b/src/teaching/write-gate.ts
@@ -1,0 +1,227 @@
+/**
+ * Write gate for the two-stage learning pipeline (Issue #41).
+ *
+ * Before any item is promoted from the staging queue to long-term knowledge,
+ * it passes through this gate. The gate scores each item on three axes:
+ *
+ * 1. Factuality  — is this an objective, verifiable statement?
+ * 2. Reusability — will this be useful across multiple future sessions?
+ * 3. Sensitivity — does this contain PII or sensitive personal data?
+ *
+ * Composite score → decision:
+ *   total >= APPROVE_THRESHOLD → approve
+ *   total >= HOLD_THRESHOLD    → hold (re-evaluate in next batch)
+ *   total <  HOLD_THRESHOLD    → reject
+ *
+ * Held items are re-evaluated up to MAX_RETRIES times.
+ */
+
+import type { StagedItem } from "./staging-queue.js";
+
+export type GateScore = {
+	/** 0–1: higher = more factual / objective. */
+	factuality: number;
+	/** 0–1: higher = more reusable across sessions. */
+	reusability: number;
+	/** 0–1: higher = more sensitive (bad). Inverted in composite score. */
+	sensitivity: number;
+	/** Composite score 0–1 used for decision. */
+	total: number;
+};
+
+export type GateDecision = "approve" | "hold" | "reject";
+
+export type GateResult = {
+	decision: GateDecision;
+	score: GateScore;
+	reason: string;
+};
+
+/** Thresholds for gate decisions. */
+const APPROVE_THRESHOLD = 0.55;
+const HOLD_THRESHOLD = 0.35;
+const MAX_RETRIES = 2;
+
+/** Minimum payload length to be considered for approval. */
+const MIN_PAYLOAD_LENGTH = 5;
+
+/** Patterns that indicate speculative/uncertain statements. */
+const SPECULATIVE_PATTERNS = [
+	/아마도/,
+	/어쩌면/,
+	/혹시/,
+	/같기도/,
+	/것\s*같/,
+	/모르겠/,
+	/가능성/,
+	/maybe/i,
+	/perhaps/i,
+	/possibly/i,
+	/might be/i,
+	/not sure/i,
+];
+
+/** Patterns indicating Personally Identifiable Information (PII). */
+const PII_PATTERNS = [
+	/비밀번호/,
+	/password/i,
+	/\d{2,3}-\d{3,4}-\d{4}/, // phone numbers
+	/\d{6}-\d{7}/, // Korean resident registration
+	/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/, // email
+	/계좌\s*번호/,
+	/카드\s*번호/,
+	/주민\s*등록/,
+	/account\s*number/i,
+	/credit\s*card/i,
+	/social\s*security/i,
+];
+
+/** Patterns indicating a general/reusable fact (not personal preference). */
+const FACTUAL_KEYWORDS = [
+	/이다$|입니다$|이야$|이에요$/m,
+	/^[A-Za-z가-힣].+는\s.+이다/m,
+	/이란\s/,
+	/정의/,
+	/설명/,
+];
+
+export class WriteGate {
+	/**
+	 * Evaluate a single staged item and return a gate decision with scores.
+	 */
+	evaluate(item: StagedItem): GateResult {
+		// Hard reject: exceeded max retries
+		if (item.retryCount > MAX_RETRIES) {
+			return {
+				decision: "reject",
+				score: zeroScore(),
+				reason: `최대 재시도 횟수 초과 (${item.retryCount}/${MAX_RETRIES})`,
+			};
+		}
+
+		// Hard reject: payload too short
+		if (item.payload.trim().length < MIN_PAYLOAD_LENGTH) {
+			return {
+				decision: "reject",
+				score: zeroScore(),
+				reason: `페이로드가 너무 짧음 (${item.payload.length} 글자)`,
+			};
+		}
+
+		const score = computeScore(item);
+
+		// Hard reject: contains sensitive data
+		if (score.sensitivity > 0.5) {
+			return {
+				decision: "reject",
+				score,
+				reason: "민감한 개인정보 패턴 감지됨",
+			};
+		}
+
+		if (score.total >= APPROVE_THRESHOLD) {
+			return {
+				decision: "approve",
+				score,
+				reason: `점수 통과 (total=${score.total.toFixed(2)})`,
+			};
+		}
+
+		if (score.total >= HOLD_THRESHOLD) {
+			return {
+				decision: "hold",
+				score,
+				reason: `점수 미달, 다음 배치에서 재평가 (total=${score.total.toFixed(2)})`,
+			};
+		}
+
+		return {
+			decision: "reject",
+			score,
+			reason: `점수 기준 미달 (total=${score.total.toFixed(2)})`,
+		};
+	}
+
+	/**
+	 * Evaluate multiple staged items at once.
+	 * Returns an array of { item, result } pairs in the same order.
+	 */
+	evaluateMany(
+		items: StagedItem[],
+	): Array<{ item: StagedItem; result: GateResult }> {
+		return items.map((item) => ({ item, result: this.evaluate(item) }));
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function zeroScore(): GateScore {
+	return { factuality: 0, reusability: 0, sensitivity: 0, total: 0 };
+}
+
+/**
+ * Compute factuality, reusability, sensitivity scores for an item.
+ */
+function computeScore(item: StagedItem): GateScore {
+	const payload = item.payload;
+
+	// --- Factuality (0-1) ---
+	let factuality = item.confidence; // base: detector confidence
+
+	// Penalise speculative language
+	const speculativeCount = SPECULATIVE_PATTERNS.filter((p) =>
+		p.test(payload),
+	).length;
+	factuality -= speculativeCount * 0.15;
+
+	// Boost for explicit type (user intentionally taught)
+	if (item.type === "explicit" || item.type === "correction") {
+		factuality = Math.min(1, factuality + 0.1);
+	}
+
+	factuality = Math.max(0, Math.min(1, factuality));
+
+	// --- Reusability (0-1) ---
+	let reusability = 0.5; // neutral base
+
+	// Factual assertions are more reusable than preferences
+	if (item.type === "preference") {
+		reusability -= 0.2;
+	}
+	if (item.type === "correction") {
+		reusability += 0.15;
+	}
+
+	// Longer payloads tend to be more specific and reusable
+	const length = payload.length;
+	if (length > 30) reusability += 0.1;
+	if (length > 60) reusability += 0.1;
+	if (length > 120) reusability += 0.05;
+
+	// Presence of factual keywords boosts reusability
+	const factualHits = FACTUAL_KEYWORDS.filter((p) => p.test(payload)).length;
+	reusability += factualHits * 0.05;
+
+	reusability = Math.max(0, Math.min(1, reusability));
+
+	// --- Sensitivity (0-1, higher = more sensitive = worse) ---
+	let sensitivity = 0;
+	const piiHits = PII_PATTERNS.filter((p) => p.test(payload)).length;
+	sensitivity = Math.min(1, piiHits * 0.6);
+
+	// --- Composite score ---
+	// Weights: factuality 0.45, reusability 0.35, safety (1-sensitivity) 0.20
+	const total =
+		factuality * 0.45 +
+		reusability * 0.35 +
+		(1 - sensitivity) * 0.2;
+
+	return {
+		factuality,
+		reusability,
+		sensitivity,
+		total: Math.max(0, Math.min(1, total)),
+	};
+}


### PR DESCRIPTION
## Summary

Closes #41

두 단계로 학습 파이프라인을 분리하여 응답 경로에서 고비용 통합 로직을 제거합니다.

- **Stage 1 (실시간, 세션 종료 직후)**: 교육 인텐트를 감지하고 `StagingQueue`에 경량 JSON으로 저장. 반영(reflection) 생성 및 관계 노트 업데이트만 수행
- **Stage 2 (배치, 1시간 주기)**: `BatchIntegrator`가 스테이징 큐를 읽어 `WriteGate` 점수 평가 후 승인/보류/거절 결정, 중복 제거 후 장기 저장소에 승격

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `src/teaching/staging-queue.ts` | 신규: 파일 기반 스테이징 큐 (pending/held/approved/rejected 상태 관리) |
| `src/teaching/write-gate.ts` | 신규: 사실성·재사용성·민감성 점수 산출 및 approve/hold/reject 결정 |
| `src/teaching/batch-integrator.ts` | 신규: 배치 처리 (dedup, gate 적용, 지식 저장, gate decision 로그) |
| `src/teaching/extractor.ts` | 수정: stagingQueue 제공 시 큐 경로, 미제공 시 기존 직접 저장 (하위 호환) |
| `src/teaching/integrator.ts` | 수정: Stage 1만 수행; stagingQueue를 extractor에 전달 |
| `src/cron/jobs.ts` | 수정: `batch-integration` cron job 추가 (1시간 주기) |

## Write Gate 기준

| 결정 | 조건 |
|------|------|
| **approve** | total score ≥ 0.55 |
| **hold** | 0.35 ≤ total < 0.55 (다음 배치에서 재평가, 최대 2회) |
| **reject** | total < 0.35, payload 너무 짧음, PII 패턴 감지, 최대 재시도 초과 |

점수 = factuality × 0.45 + reusability × 0.35 + (1-sensitivity) × 0.20

## 테스트

- [x] `StagingQueue`: enqueue, listPending/Held, updateStatus, expireOld (8 tests)
- [x] `WriteGate`: 승인/보류/거절 결정, PII 감지, 재시도 정책, 점수 구조 (16 tests)
- [x] `BatchIntegrator`: 배치 실행, dedup, gate 로그, held 재평가, 결과 집계 (11 tests)
- [x] `KnowledgeManager` 기존 테스트 전체 통과 (45 tests)
- [x] 빌드 오류 없음

## Test plan

- [ ] stagingQueue 없이 기존 코드 경로 (legacy) 동작 확인
- [ ] stagingQueue 있을 때 세션 종료 후 큐에 아이템이 들어가는지 확인
- [ ] 배치 실행 후 gate decision 로그가 남는지 확인
- [ ] PII 패턴(전화번호, 이메일, 비밀번호)이 reject되는지 확인
- [ ] held 아이템이 다음 배치에서 재평가되는지 확인
- [ ] dedup이 중복 지식을 올바르게 건너뛰는지 확인