### PR TITLE
feat: 충돌 인식 지식 저장 도입 (supersedes/refutes 관계) (#43)

### DIFF
--- a/src/knowledge-feed/subscriber.ts
+++ b/src/knowledge-feed/subscriber.ts
@@ -100,6 +100,7 @@ export class FeedSubscriber {
 				tier: "scratchpad",
 				tierCreatedAt: now,
 				promotionScore: 0,
+				relations: [],
 			};
 
 			await this.knowledge.upsert(localEntry);

--- a/src/memory/knowledge-conflict.test.ts
+++ b/src/memory/knowledge-conflict.test.ts
@@ -1,0 +1,662 @@
+/**
+ * Tests for conflict-aware knowledge storage (Issue #43).
+ *
+ * Covers:
+ * - detectConflicts: topic/similarity-based conflict detection
+ * - saveWithRelation: storing entries with supersedes/refutes links
+ * - getCanonical: canonical selection and history separation
+ * - upsertWithConflictDetection: auto-detect and store with relations
+ * - search exclusion of superseded entries
+ * - Regression: conflicting info preserves original history
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { KnowledgeRelation } from "./knowledge.js";
+import { KnowledgeManager } from "./knowledge.js";
+import type { KnowledgeEntry } from "./knowledge.js";
+
+function makeTempDir(): string {
+	return join(tmpdir(), `claude-pet-conflict-test-${randomUUID()}`);
+}
+
+function makeEntry(overrides: Partial<KnowledgeEntry> = {}): KnowledgeEntry {
+	const now = Date.now();
+	return {
+		id: randomUUID(),
+		topic: "test topic",
+		content: "test content",
+		source: "taught",
+		taughtBy: "user1",
+		createdAt: now,
+		updatedAt: now,
+		confidence: 0.8,
+		tags: [],
+		strength: 1.0,
+		lastReferencedAt: now,
+		referenceCount: 0,
+		tier: "scratchpad",
+		tierCreatedAt: now,
+		promotionScore: 0,
+		relations: [],
+		...overrides,
+	};
+}
+
+describe("Conflict-aware knowledge storage (Issue #43)", () => {
+	let memoryDir: string;
+	let archiveDir: string;
+	let manager: KnowledgeManager;
+
+	beforeEach(async () => {
+		memoryDir = makeTempDir();
+		archiveDir = join(memoryDir, "..", "archive");
+		await mkdir(memoryDir, { recursive: true });
+		manager = new KnowledgeManager(memoryDir, archiveDir);
+	});
+
+	// -----------------------------------------------------------------------
+	// detectConflicts
+	// -----------------------------------------------------------------------
+
+	describe("detectConflicts", () => {
+		it("returns empty result when no existing entries for topic", async () => {
+			const result = await manager.detectConflicts("new topic", "some content");
+			expect(result.conflictingIds).toHaveLength(0);
+			expect(result.suggestedRelations).toHaveLength(0);
+		});
+
+		it("detects conflict when same-topic entry exists with similar content (supersedes)", async () => {
+			const existing = makeEntry({
+				topic: "Python best practices",
+				content: "Use list comprehensions over map and filter for clarity",
+				confidence: 0.8,
+			});
+			await manager.upsert(existing);
+
+			// Overlapping content → supersedes
+			const result = await manager.detectConflicts(
+				"Python best practices",
+				"Use list comprehensions instead of map and filter for readability",
+			);
+
+			expect(result.conflictingIds).toContain(existing.id);
+			const suggestion = result.suggestedRelations.find(
+				(r) => r.targetId === existing.id,
+			);
+			expect(suggestion?.type).toBe("supersedes");
+		});
+
+		it("detects conflict when same-topic entry exists with divergent content (refutes)", async () => {
+			const existing = makeEntry({
+				topic: "TypeScript null safety",
+				content: "Always enable strictNullChecks in tsconfig",
+				confidence: 0.8,
+			});
+			await manager.upsert(existing);
+
+			// Completely different content on same topic → refutes
+			const result = await manager.detectConflicts(
+				"TypeScript null safety",
+				"Disable strictNullChecks to avoid verbose null checks",
+			);
+
+			expect(result.conflictingIds).toContain(existing.id);
+			const suggestion = result.suggestedRelations.find(
+				(r) => r.targetId === existing.id,
+			);
+			expect(suggestion?.type).toBe("refutes");
+		});
+
+		it("excludes already-superseded entries from conflict detection", async () => {
+			const old = makeEntry({
+				topic: "React state",
+				content: "Use setState to update component state",
+				supersededBy: "newer-id",
+			});
+			await manager.upsert(old);
+
+			const result = await manager.detectConflicts(
+				"React state",
+				"Use useState hook to manage component state",
+			);
+
+			// The superseded entry should be skipped
+			expect(result.conflictingIds).not.toContain(old.id);
+		});
+
+		it("detects multiple conflicts when multiple active entries exist on same topic", async () => {
+			const e1 = makeEntry({
+				topic: "database indexing",
+				content: "Add index on frequently queried columns",
+			});
+			const e2 = makeEntry({
+				topic: "database indexing",
+				content: "Use composite index for multi-column queries",
+			});
+			await manager.upsert(e1);
+			await manager.upsert(e2);
+
+			const result = await manager.detectConflicts(
+				"database indexing",
+				"Index only the most critical columns to avoid write overhead",
+			);
+
+			// At least one conflict detected
+			expect(result.conflictingIds.length).toBeGreaterThan(0);
+		});
+
+		it("no conflict when topic differs entirely", async () => {
+			const existing = makeEntry({
+				topic: "Go routines",
+				content: "Use goroutines for concurrent tasks",
+			});
+			await manager.upsert(existing);
+
+			const result = await manager.detectConflicts(
+				"Python async",
+				"Use asyncio for async programming",
+			);
+
+			expect(result.conflictingIds).toHaveLength(0);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// saveWithRelation
+	// -----------------------------------------------------------------------
+
+	describe("saveWithRelation", () => {
+		it("stores new entry with supersedes relation and marks target as supersededBy", async () => {
+			const old = makeEntry({
+				topic: "Node.js version",
+				content: "Node 16 is LTS",
+			});
+			await manager.upsert(old);
+
+			const newEntry = makeEntry({
+				topic: "Node.js version",
+				content: "Node 20 is LTS",
+				confidence: 0.95,
+			});
+
+			const relation: KnowledgeRelation = {
+				type: "supersedes",
+				targetId: old.id,
+				rationale: "Node 20 is now the LTS version",
+				createdAt: Date.now(),
+			};
+
+			await manager.saveWithRelation(newEntry, relation);
+
+			// New entry stored with relation
+			const stored = await manager.get(newEntry.id);
+			expect(stored).not.toBeNull();
+			expect(stored?.relations).toHaveLength(1);
+			expect(stored?.relations[0]?.type).toBe("supersedes");
+			expect(stored?.relations[0]?.targetId).toBe(old.id);
+
+			// Old entry marked as superseded (but still exists)
+			const oldStored = await manager.get(old.id);
+			expect(oldStored).not.toBeNull();
+			expect(oldStored?.supersededBy).toBe(newEntry.id);
+		});
+
+		it("stores new entry with refutes relation WITHOUT marking target as superseded", async () => {
+			const claim = makeEntry({
+				topic: "JavaScript performance",
+				content: "eval() is fast for dynamic code execution",
+			});
+			await manager.upsert(claim);
+
+			const counter = makeEntry({
+				topic: "JavaScript performance",
+				content: "eval() is slow and unsafe — avoid it",
+				confidence: 0.9,
+			});
+
+			const relation: KnowledgeRelation = {
+				type: "refutes",
+				targetId: claim.id,
+				rationale: "eval() has significant overhead and security risks",
+				createdAt: Date.now(),
+			};
+
+			await manager.saveWithRelation(counter, relation);
+
+			// Counter stored with relation
+			const stored = await manager.get(counter.id);
+			expect(stored?.relations[0]?.type).toBe("refutes");
+
+			// Original NOT marked as superseded
+			const claimStored = await manager.get(claim.id);
+			expect(claimStored?.supersededBy).toBeUndefined();
+		});
+
+		it("preserves original entry's content after saveWithRelation (history preserved)", async () => {
+			const original = makeEntry({
+				topic: "API versioning",
+				content: "Use URL path versioning: /v1/users",
+			});
+			await manager.upsert(original);
+
+			const updated = makeEntry({
+				topic: "API versioning",
+				content: "Use header versioning: Accept: application/vnd.api+json;version=2",
+				confidence: 0.9,
+			});
+
+			const relation: KnowledgeRelation = {
+				type: "supersedes",
+				targetId: original.id,
+				rationale: "Header versioning is more RESTful",
+				createdAt: Date.now(),
+			};
+
+			await manager.saveWithRelation(updated, relation);
+
+			// Original still readable with original content
+			const originalStored = await manager.get(original.id);
+			expect(originalStored?.content).toBe("Use URL path versioning: /v1/users");
+			expect(originalStored?.supersededBy).toBe(updated.id);
+		});
+
+		it("attaches rationale to the stored relation", async () => {
+			const old = makeEntry({ topic: "caching strategy", content: "Use Redis" });
+			await manager.upsert(old);
+
+			const newer = makeEntry({ topic: "caching strategy", content: "Use Memcached" });
+			const relation: KnowledgeRelation = {
+				type: "supersedes",
+				targetId: old.id,
+				rationale: "Memcached is preferred for simple caching",
+				createdAt: Date.now(),
+			};
+
+			await manager.saveWithRelation(newer, relation);
+
+			const stored = await manager.get(newer.id);
+			expect(stored?.relations[0]?.rationale).toBe(
+				"Memcached is preferred for simple caching",
+			);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// getCanonical
+	// -----------------------------------------------------------------------
+
+	describe("getCanonical", () => {
+		it("returns null when no entries exist for topic", async () => {
+			const result = await manager.getCanonical("unknown topic");
+			expect(result).toBeNull();
+		});
+
+		it("returns single entry as canonical when only one exists", async () => {
+			const entry = makeEntry({ topic: "Docker basics", content: "Containers are isolated" });
+			await manager.upsert(entry);
+
+			const result = await manager.getCanonical("Docker basics");
+
+			expect(result).not.toBeNull();
+			expect(result?.canonical.id).toBe(entry.id);
+			expect(result?.history).toHaveLength(0);
+		});
+
+		it("returns active (non-superseded) entry as canonical", async () => {
+			const old = makeEntry({
+				topic: "Node.js LTS",
+				content: "Node 16 is LTS",
+				confidence: 0.8,
+			});
+			await manager.upsert(old);
+
+			const current = makeEntry({
+				topic: "Node.js LTS",
+				content: "Node 20 is LTS",
+				confidence: 0.95,
+			});
+			const relation: KnowledgeRelation = {
+				type: "supersedes",
+				targetId: old.id,
+				rationale: "Node 20 released",
+				createdAt: Date.now(),
+			};
+			await manager.saveWithRelation(current, relation);
+
+			const result = await manager.getCanonical("Node.js LTS");
+
+			expect(result).not.toBeNull();
+			expect(result?.canonical.id).toBe(current.id);
+			expect(result?.history.map((h) => h.id)).toContain(old.id);
+		});
+
+		it("separates canonical from history correctly (supersedes chain)", async () => {
+			const v1 = makeEntry({
+				topic: "deployment strategy",
+				content: "FTP deploy",
+				confidence: 0.7,
+				createdAt: Date.now() - 2000,
+			});
+			const v2 = makeEntry({
+				topic: "deployment strategy",
+				content: "CI/CD pipeline",
+				confidence: 0.9,
+				createdAt: Date.now() - 1000,
+			});
+			await manager.upsert(v1);
+			await manager.saveWithRelation(v2, {
+				type: "supersedes",
+				targetId: v1.id,
+				rationale: "Modern approach",
+				createdAt: Date.now() - 1000,
+			});
+
+			const result = await manager.getCanonical("deployment strategy");
+
+			expect(result?.canonical.id).toBe(v2.id);
+			expect(result?.history).toHaveLength(1);
+			expect(result?.history[0]?.id).toBe(v1.id);
+		});
+
+		it("picks highest-confidence active entry when multiple active entries exist", async () => {
+			const lowConf = makeEntry({
+				topic: "sorting algorithms",
+				content: "Bubble sort is simple",
+				confidence: 0.6,
+			});
+			const highConf = makeEntry({
+				topic: "sorting algorithms",
+				content: "QuickSort is efficient for most cases",
+				confidence: 0.95,
+			});
+
+			await manager.upsert(lowConf);
+			await manager.upsert(highConf);
+
+			const result = await manager.getCanonical("sorting algorithms");
+
+			expect(result?.canonical.id).toBe(highConf.id);
+			expect(result?.history.map((h) => h.id)).toContain(lowConf.id);
+		});
+
+		it("returns both active entries when refutes relation (neither superseded)", async () => {
+			const claim = makeEntry({
+				topic: "tabs vs spaces",
+				content: "Use tabs for indentation",
+				confidence: 0.7,
+			});
+			const counter = makeEntry({
+				topic: "tabs vs spaces",
+				content: "Use spaces for indentation",
+				confidence: 0.85,
+			});
+			await manager.upsert(claim);
+			await manager.saveWithRelation(counter, {
+				type: "refutes",
+				targetId: claim.id,
+				rationale: "Style guide preference",
+				createdAt: Date.now(),
+			});
+
+			const result = await manager.getCanonical("tabs vs spaces");
+
+			// counter has higher confidence → canonical
+			expect(result?.canonical.id).toBe(counter.id);
+			// claim is still active (not superseded) → in history
+			expect(result?.history.map((h) => h.id)).toContain(claim.id);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// upsertWithConflictDetection
+	// -----------------------------------------------------------------------
+
+	describe("upsertWithConflictDetection", () => {
+		it("stores entry normally when no conflicts exist", async () => {
+			const entry = makeEntry({
+				topic: "unique topic abc",
+				content: "some content",
+			});
+
+			const result = await manager.upsertWithConflictDetection(entry);
+
+			expect(result.conflictsFound).toBe(0);
+			const stored = await manager.get(entry.id);
+			expect(stored).not.toBeNull();
+		});
+
+		it("detects and links conflicting entries automatically", async () => {
+			const existing = makeEntry({
+				topic: "memory management",
+				content: "Manual memory allocation with malloc and free",
+			});
+			await manager.upsert(existing);
+
+			const newEntry = makeEntry({
+				topic: "memory management",
+				content: "Automatic memory management with garbage collection",
+			});
+
+			const result = await manager.upsertWithConflictDetection(newEntry);
+
+			expect(result.conflictsFound).toBeGreaterThan(0);
+
+			const stored = await manager.get(newEntry.id);
+			expect(stored?.relations.length).toBeGreaterThan(0);
+		});
+
+		it("returns conflictsFound count matching actual conflicts", async () => {
+			const e1 = makeEntry({ topic: "logging", content: "Use console.log for debugging" });
+			const e2 = makeEntry({ topic: "logging", content: "Use a logger library" });
+			await manager.upsert(e1);
+			await manager.upsert(e2);
+
+			const newEntry = makeEntry({
+				topic: "logging",
+				content: "Structured logging with JSON output is preferred",
+			});
+
+			const result = await manager.upsertWithConflictDetection(newEntry);
+
+			expect(result.conflictsFound).toBe(2);
+		});
+
+		it("existing entry is marked supersededBy when new entry supersedes it", async () => {
+			const old = makeEntry({
+				topic: "CSS framework",
+				content: "Use Bootstrap for responsive design and rapid prototyping",
+			});
+			await manager.upsert(old);
+
+			const updated = makeEntry({
+				topic: "CSS framework",
+				content: "Use Tailwind CSS for responsive design and rapid prototyping with utilities",
+				confidence: 0.95,
+			});
+
+			await manager.upsertWithConflictDetection(updated);
+
+			// Check if old is marked superseded
+			const oldStored = await manager.get(old.id);
+			// The auto-detection should have superseded the similar entry
+			expect(oldStored?.supersededBy).toBe(updated.id);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// search exclusion of superseded entries
+	// -----------------------------------------------------------------------
+
+	describe("search excludes superseded entries", () => {
+		it("excludes superseded entry from search results", async () => {
+			const old = makeEntry({
+				topic: "async patterns",
+				content: "Use callbacks for async operations",
+				strength: 0.8,
+				confidence: 0.8,
+			});
+			await manager.upsert(old);
+
+			const current = makeEntry({
+				topic: "async patterns",
+				content: "Use Promises or async/await for async operations",
+				strength: 0.8,
+				confidence: 0.95,
+			});
+			await manager.saveWithRelation(current, {
+				type: "supersedes",
+				targetId: old.id,
+				rationale: "Modern async patterns",
+				createdAt: Date.now(),
+			});
+
+			const results = await manager.search("async patterns");
+			const ids = results.map((r) => r.id);
+
+			expect(ids).toContain(current.id);
+			expect(ids).not.toContain(old.id);
+		});
+
+		it("includes refuted entries in search results (both active)", async () => {
+			const claim = makeEntry({
+				topic: "test strategy",
+				content: "Unit tests are sufficient for quality assurance",
+				strength: 0.8,
+				confidence: 0.7,
+			});
+			const counter = makeEntry({
+				topic: "test strategy",
+				content: "Integration tests are necessary in addition to unit tests",
+				strength: 0.8,
+				confidence: 0.85,
+			});
+			await manager.upsert(claim);
+			await manager.saveWithRelation(counter, {
+				type: "refutes",
+				targetId: claim.id,
+				rationale: "Need multiple test layers",
+				createdAt: Date.now(),
+			});
+
+			const results = await manager.search("test strategy");
+			const ids = results.map((r) => r.id);
+
+			// Both should appear since neither was superseded
+			expect(ids).toContain(claim.id);
+			expect(ids).toContain(counter.id);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// Regression: conflicting info preserves original history
+	// -----------------------------------------------------------------------
+
+	describe("history preservation", () => {
+		it("superseded entry is NOT deleted — retrievable by ID", async () => {
+			const original = makeEntry({
+				topic: "HTTP methods",
+				content: "GET for reading, POST for creating",
+			});
+			await manager.upsert(original);
+
+			const updated = makeEntry({
+				topic: "HTTP methods",
+				content: "GET, POST, PUT, PATCH, DELETE — full REST verbs",
+				confidence: 0.95,
+			});
+			await manager.saveWithRelation(updated, {
+				type: "supersedes",
+				targetId: original.id,
+				rationale: "More complete description",
+				createdAt: Date.now(),
+			});
+
+			// Original must still be retrievable
+			const originalStored = await manager.get(original.id);
+			expect(originalStored).not.toBeNull();
+			expect(originalStored?.content).toBe("GET for reading, POST for creating");
+		});
+
+		it("supersedes chain is navigable via relations", async () => {
+			const v1 = makeEntry({ topic: "auth strategy", content: "Basic auth", confidence: 0.6 });
+			const v2 = makeEntry({ topic: "auth strategy", content: "JWT auth", confidence: 0.8 });
+			const v3 = makeEntry({ topic: "auth strategy", content: "OAuth2 with PKCE", confidence: 0.95 });
+
+			await manager.upsert(v1);
+			await manager.saveWithRelation(v2, {
+				type: "supersedes",
+				targetId: v1.id,
+				rationale: "JWT more scalable",
+				createdAt: Date.now() - 1000,
+			});
+			await manager.saveWithRelation(v3, {
+				type: "supersedes",
+				targetId: v2.id,
+				rationale: "OAuth2 is more secure",
+				createdAt: Date.now(),
+			});
+
+			// v3 is canonical
+			const canonical = await manager.getCanonical("auth strategy");
+			expect(canonical?.canonical.id).toBe(v3.id);
+
+			// v1 and v2 are in history
+			const historyIds = canonical?.history.map((h) => h.id) ?? [];
+			expect(historyIds).toContain(v1.id);
+			expect(historyIds).toContain(v2.id);
+
+			// v2 has relation to v1
+			const v2Stored = await manager.get(v2.id);
+			expect(v2Stored?.relations.some((r) => r.targetId === v1.id)).toBe(true);
+
+			// v3 has relation to v2
+			const v3Stored = await manager.get(v3.id);
+			expect(v3Stored?.relations.some((r) => r.targetId === v2.id)).toBe(true);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// KnowledgeEntry schema — backward compatibility with new relation fields
+	// -----------------------------------------------------------------------
+
+	describe("backward compatibility with relation fields", () => {
+		it("reads entries without relations field and defaults to empty array", async () => {
+			const { writeFile } = await import("node:fs/promises");
+			const { join: pathJoin } = await import("node:path");
+
+			const id = randomUUID();
+			const oldEntry = {
+				id,
+				topic: "legacy topic",
+				content: "legacy content",
+				source: "taught",
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+				confidence: 0.8,
+				tags: [],
+				strength: 1.0,
+				lastReferencedAt: Date.now(),
+				referenceCount: 0,
+				tier: "scratchpad",
+				tierCreatedAt: Date.now(),
+				promotionScore: 0,
+				// No relations or supersededBy fields
+			};
+			const safeName = id.replace(/[^a-zA-Z0-9_-]/g, "_");
+			await writeFile(
+				pathJoin(memoryDir, `${safeName}.json`),
+				JSON.stringify(oldEntry, null, 2),
+				"utf8",
+			);
+
+			const read = await manager.get(id);
+			expect(read).not.toBeNull();
+			expect(read?.relations).toEqual([]);
+			expect(read?.supersededBy).toBeUndefined();
+		});
+	});
+});

--- a/src/memory/knowledge.ts
+++ b/src/memory/knowledge.ts
@@ -11,6 +11,11 @@
  * - scratchpad: short-lived (TTL-based), immediate storage
  * - working: mid-term, promoted from scratchpad
  * - long-term: durable, verified knowledge
+ *
+ * Conflict-aware knowledge storage (Issue #43):
+ * - supersedes: new entry replaces an older one (old entry preserved as history)
+ * - refutes: new entry contradicts an older one (both preserved)
+ * - canonical chain prioritises highest confidence + most recent superseder
  */
 
 import { z } from "zod";
@@ -50,6 +55,41 @@ export type TierStats = {
 	total: number;
 };
 
+// -----------------------------------------------------------------------
+// Conflict-aware types (Issue #43)
+// -----------------------------------------------------------------------
+
+/** Relation type between knowledge entries. */
+export type KnowledgeRelationType = "supersedes" | "refutes";
+
+/** A directed relation from one knowledge entry to another. */
+export type KnowledgeRelation = {
+	/** The type of relation. */
+	type: KnowledgeRelationType;
+	/** ID of the related entry (the one being superseded or refuted). */
+	targetId: string;
+	/** Human-readable rationale for the relation. */
+	rationale: string;
+	/** Timestamp (ms) when the relation was established. */
+	createdAt: number;
+};
+
+/** Result of a conflict detection scan. */
+export type ConflictDetectionResult = {
+	/** IDs of existing entries that conflict with the new entry. */
+	conflictingIds: string[];
+	/** Suggested relation types for each conflicting entry. */
+	suggestedRelations: Array<{ targetId: string; type: KnowledgeRelationType }>;
+};
+
+/** Result of getCanonical query. */
+export type CanonicalResult = {
+	/** The best (canonical) entry for the topic. */
+	canonical: KnowledgeEntry;
+	/** All related historical entries (superseded / refuted). */
+	history: KnowledgeEntry[];
+};
+
 /**
  * Compute the promotion score for a knowledge entry.
  * promotionScore = referenceCount * 0.4 + confidence * 0.4 + (strength > 0.7 ? 0.2 : 0)
@@ -61,6 +101,13 @@ function computePromotionScore(
 ): number {
 	return referenceCount * 0.4 + confidence * 0.4 + (strength > 0.7 ? 0.2 : 0);
 }
+
+const KnowledgeRelationSchema = z.object({
+	type: z.enum(["supersedes", "refutes"]),
+	targetId: z.string(),
+	rationale: z.string(),
+	createdAt: z.number(),
+});
 
 const KnowledgeEntrySchema = z.object({
 	id: z.string(),
@@ -90,6 +137,20 @@ const KnowledgeEntrySchema = z.object({
 	promotionScore: z.number().default(0),
 	/** Custom TTL (ms) for scratchpad entries. Defaults to DEFAULT_SCRATCHPAD_TTL_MS if not set. */
 	scratchpadTtlMs: z.number().optional(),
+	// -----------------------------------------------------------------------
+	// Conflict-aware fields (Issue #43)
+	// -----------------------------------------------------------------------
+	/**
+	 * Relations this entry has to other entries.
+	 * supersedes: this entry replaces the target.
+	 * refutes: this entry contradicts the target.
+	 */
+	relations: z.array(KnowledgeRelationSchema).optional().default([]),
+	/**
+	 * Whether this entry has been superseded by a newer entry.
+	 * Superseded entries are preserved for history but excluded from canonical results.
+	 */
+	supersededBy: z.string().optional(),
 });
 
 export type KnowledgeEntry = z.output<typeof KnowledgeEntrySchema>;
@@ -117,12 +178,13 @@ export class KnowledgeManager {
 
 	/** Store a new knowledge entry or update existing one. */
 	async upsert(
-		entry: Omit<KnowledgeEntry, "updatedAt" | "tier" | "tierCreatedAt" | "promotionScore"> &
-			Partial<Pick<KnowledgeEntry, "tier" | "tierCreatedAt" | "promotionScore">>,
+		entry: Omit<KnowledgeEntry, "updatedAt" | "tier" | "tierCreatedAt" | "promotionScore" | "relations" | "supersededBy"> &
+			Partial<Pick<KnowledgeEntry, "tier" | "tierCreatedAt" | "promotionScore" | "relations" | "supersededBy">>,
 	): Promise<void> {
 		const now = Date.now();
 		const withTimestamp: KnowledgeEntry = {
 			tier: "scratchpad",
+			relations: [],
 			...entry,
 			updatedAt: now,
 			tierCreatedAt: entry.tierCreatedAt ?? now,
@@ -244,7 +306,9 @@ export class KnowledgeManager {
 			.slice(0, limit);
 	}
 
-	/** Search knowledge by keyword matching with tier-priority weighting. */
+	/** Search knowledge by keyword matching with tier-priority weighting.
+	 * Excludes entries that have been superseded by a newer entry.
+	 */
 	async search(query: string, limit = 10): Promise<KnowledgeEntry[]> {
 		const all = await this.store.readAll();
 		const queryLower = query.toLowerCase();
@@ -256,7 +320,10 @@ export class KnowledgeManager {
 			}))
 			.filter(
 				({ score, entry }) =>
-					score > 0 && entry.strength >= DEPRIORITIZE_THRESHOLD,
+					score > 0 &&
+					entry.strength >= DEPRIORITIZE_THRESHOLD &&
+					// Exclude superseded entries from canonical search results
+					!entry.supersededBy,
 			)
 			.sort((a, b) => b.score - a.score)
 			.slice(0, limit);
@@ -450,6 +517,7 @@ export class KnowledgeManager {
 	/**
 	 * Format relevant knowledge for prompt injection.
 	 * Returns { text, entryIds } so the caller can fire-and-forget reinforce.
+	 * Excludes entries that have been superseded.
 	 */
 	async toPromptSection(
 		query: string,
@@ -472,6 +540,190 @@ export class KnowledgeManager {
 
 		return { text: lines.join("\n"), entryIds };
 	}
+
+	// -------------------------------------------------------------------------
+	// Conflict-aware knowledge storage (Issue #43)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Detect conflicts between a new entry's topic/content and existing entries.
+	 * Uses topic exact-match and Jaccard similarity to find candidates.
+	 * Returns conflicting IDs and suggested relation types.
+	 */
+	async detectConflicts(
+		topic: string,
+		content: string,
+	): Promise<ConflictDetectionResult> {
+		const topicMatches = await this.findByTopic(topic);
+		const conflictingIds: string[] = [];
+		const suggestedRelations: Array<{ targetId: string; type: KnowledgeRelationType }> = [];
+
+		for (const existing of topicMatches) {
+			// Skip already-superseded entries — they are history, not active knowledge
+			if (existing.supersededBy) continue;
+
+			const sim = jaccardSimilarity(existing.content, content);
+			// High similarity but different content → supersedes (updated info)
+			// Low similarity on same topic → refutes (contradictory claim)
+			if (sim >= 0.3) {
+				conflictingIds.push(existing.id);
+				suggestedRelations.push({ targetId: existing.id, type: "supersedes" });
+			} else if (sim < 0.3) {
+				conflictingIds.push(existing.id);
+				suggestedRelations.push({ targetId: existing.id, type: "refutes" });
+			}
+		}
+
+		return { conflictingIds, suggestedRelations };
+	}
+
+	/**
+	 * Store a knowledge entry with an explicit relation to an existing entry.
+	 * If relationType is "supersedes", the target entry is marked as supersededBy this entry.
+	 * Both entries are preserved in the store (original history is never deleted).
+	 * Logs a conflict detection/resolution event.
+	 */
+	async saveWithRelation(
+		entry: Omit<KnowledgeEntry, "updatedAt" | "tier" | "tierCreatedAt" | "promotionScore" | "relations" | "supersededBy"> &
+			Partial<Pick<KnowledgeEntry, "tier" | "tierCreatedAt" | "promotionScore" | "relations" | "supersededBy">>,
+		relation: KnowledgeRelation,
+	): Promise<void> {
+		const now = Date.now();
+
+		// Build the new entry with the relation
+		const newEntry: KnowledgeEntry = {
+			tier: "scratchpad",
+			...entry,
+			updatedAt: now,
+			tierCreatedAt: entry.tierCreatedAt ?? now,
+			promotionScore: computePromotionScore(
+				entry.referenceCount,
+				entry.confidence,
+				entry.strength,
+			),
+			relations: [...(entry.relations ?? []), relation],
+		};
+		await this.store.write(entry.id, newEntry);
+
+		// If supersedes, mark the target as superseded (but keep it for history)
+		if (relation.type === "supersedes") {
+			const target = await this.store.read(relation.targetId);
+			if (target) {
+				const updatedTarget: KnowledgeEntry = {
+					...target,
+					supersededBy: entry.id,
+					updatedAt: now,
+				};
+				await this.store.write(relation.targetId, updatedTarget);
+				logger.info("Knowledge conflict resolved: supersedes", {
+					newId: entry.id,
+					targetId: relation.targetId,
+					topic: entry.topic,
+					rationale: relation.rationale,
+				});
+			}
+		} else {
+			// refutes — log without marking superseded (both remain active)
+			logger.info("Knowledge conflict detected: refutes", {
+				newId: entry.id,
+				targetId: relation.targetId,
+				topic: entry.topic,
+				rationale: relation.rationale,
+			});
+		}
+	}
+
+	/**
+	 * Get the canonical (most current/authoritative) entry for a topic,
+	 * plus the historical chain of superseded/refuted entries.
+	 *
+	 * Canonical selection:
+	 * 1. Exclude entries that have been superseded by a newer entry.
+	 * 2. Among remaining, prefer highest confidence, then most recent createdAt.
+	 *
+	 * Returns null if no entries exist for the topic.
+	 */
+	async getCanonical(topic: string): Promise<CanonicalResult | null> {
+		const all = await this.findByTopic(topic);
+		if (all.length === 0) return null;
+
+		// Partition into active (not superseded) and historical
+		const active = all.filter((e) => !e.supersededBy);
+		const historical = all.filter((e) => !!e.supersededBy);
+
+		if (active.length === 0) {
+			// All superseded — return the most recently updated one as canonical
+			const sorted = [...all].sort((a, b) => b.updatedAt - a.updatedAt);
+			return { canonical: sorted[0]!, history: sorted.slice(1) };
+		}
+
+		// Sort active by confidence desc, then createdAt desc
+		const sorted = [...active].sort(
+			(a, b) => b.confidence - a.confidence || b.createdAt - a.createdAt,
+		);
+
+		return {
+			canonical: sorted[0]!,
+			history: [...sorted.slice(1), ...historical],
+		};
+	}
+
+	/**
+	 * Detect conflicts and auto-save with appropriate relations.
+	 * This is the main entry point for conflict-aware storage.
+	 *
+	 * If conflicts are found:
+	 * - Logs a conflict-detection event
+	 * - Stores the new entry linked to existing entries via relations
+	 * - Marks superseded entries accordingly
+	 *
+	 * If no conflicts, falls back to plain upsert.
+	 *
+	 * @returns The stored entry.
+	 */
+	async upsertWithConflictDetection(
+		entry: Omit<KnowledgeEntry, "updatedAt" | "tier" | "tierCreatedAt" | "promotionScore" | "relations" | "supersededBy"> &
+			Partial<Pick<KnowledgeEntry, "tier" | "tierCreatedAt" | "promotionScore" | "relations" | "supersededBy">>,
+	): Promise<{ entry: KnowledgeEntry; conflictsFound: number }> {
+		const detection = await this.detectConflicts(entry.topic, entry.content);
+
+		if (detection.conflictingIds.length === 0) {
+			await this.upsert(entry);
+			const stored = await this.store.read(entry.id);
+			return { entry: stored!, conflictsFound: 0 };
+		}
+
+		// Log the conflict detection event
+		logger.info("Knowledge conflict detection event", {
+			newId: entry.id,
+			topic: entry.topic,
+			conflictingIds: detection.conflictingIds,
+			suggestedRelations: detection.suggestedRelations,
+		});
+
+		// Build relations for all conflicts
+		const now = Date.now();
+		const relations: KnowledgeRelation[] = detection.suggestedRelations.map(
+			({ targetId, type }) => ({
+				type,
+				targetId,
+				rationale: `Auto-detected: new entry ${type} existing entry on topic "${entry.topic}"`,
+				createdAt: now,
+			}),
+		);
+
+		// Save with the first relation; remaining relations are embedded in the entry
+		const firstRelation = relations[0]!;
+		const additionalRelations = relations.slice(1);
+
+		await this.saveWithRelation(
+			{ ...entry, relations: [...(entry.relations ?? []), ...additionalRelations] },
+			firstRelation,
+		);
+
+		const stored = await this.store.read(entry.id);
+		return { entry: stored!, conflictsFound: detection.conflictingIds.length };
+	}
 }
 
 /** Render a visual strength bar: ████░░ */
@@ -479,6 +731,17 @@ function renderStrengthBar(strength: number): string {
 	const filled = Math.round(strength * 6);
 	const empty = 6 - filled;
 	return `[강도: ${"█".repeat(filled)}${"░".repeat(empty)}]`;
+}
+
+/**
+ * Compute Jaccard similarity between two strings (word-level).
+ */
+function jaccardSimilarity(a: string, b: string): number {
+	const wordsA = new Set(a.toLowerCase().split(/\s+/).filter(Boolean));
+	const wordsB = new Set(b.toLowerCase().split(/\s+/).filter(Boolean));
+	const intersection = [...wordsA].filter((w) => wordsB.has(w)).length;
+	const union = new Set([...wordsA, ...wordsB]).size;
+	return union === 0 ? 0 : intersection / union;
 }
 
 /**

--- a/src/teaching/extractor.ts
+++ b/src/teaching/extractor.ts
@@ -99,14 +99,16 @@ export class KnowledgeExtractor {
 				tier: "scratchpad",
 				tierCreatedAt: now,
 				promotionScore: 0,
+				relations: [],
 			};
 
-			await this.knowledge.upsert(entry);
+			const { conflictsFound } = await this.knowledge.upsertWithConflictDetection(entry);
 			entries.push(entry);
 			logger.info("Knowledge stored", {
 				topic,
 				id: entry.id,
 				source: entry.source,
+				conflictsFound,
 			});
 
 			// Publish to shared feed for cross-pet propagation


### PR DESCRIPTION
## Summary

- `KnowledgeEntry`에 `relations[]` 및 `supersededBy` 필드 추가 (하위 호환 유지)
- 저장 시 충돌 탐지: 동일 토픽 + Jaccard 유사도 기반으로 `supersedes`/`refutes` 관계 자동 제안
- `saveWithRelation()`: 명시적 관계로 저장하며, `supersedes`인 경우 기존 항목에 `supersededBy` 마킹 (원본 삭제 없이 이력 보존)
- `getCanonical()`: 활성(superseded되지 않은) 항목 중 신뢰도 최고 항목을 canonical로 반환하고 이력 체인 분리 제공
- `upsertWithConflictDetection()`: 자동 충돌 탐지 후 관계 연결 + 운영 로그 기록
- `search()`: superseded 항목은 검색 결과에서 제외
- `KnowledgeExtractor`: 신규 지식 저장 시 `upsertWithConflictDetection()` 사용

## Acceptance Criteria

- [x] 상충 정보 입력 시 기존 항목 삭제 없이 관계로 연결됨
- [x] 동일 토픽 조회 시 `getCanonical()`로 canonical/이력 분리 제공
- [x] supersedes/refutes 체인이 25개 테스트로 검증됨
- [x] 운영 로그에 충돌 탐지/해결 이벤트 기록

## Test plan

- [x] `detectConflicts`: 토픽 일치 + 유사도 기반 충돌 탐지 (supersedes/refutes 분류)
- [x] `saveWithRelation`: supersedes 저장 시 기존 항목 `supersededBy` 마킹, refutes는 양쪽 유지
- [x] `getCanonical`: 단일/다중 항목, 전체 superseded, refutes 케이스
- [x] `upsertWithConflictDetection`: 자동 충돌 감지 및 관계 저장
- [x] `search`: superseded 항목 제외, refuted 항목 포함 확인
- [x] 역방향 호환: `relations` 필드 없는 구 항목 기본값 [] 처리
- [x] supersedes 체인 3단계 내비게이션 테스트

🤖 Generated with Claude Code